### PR TITLE
fix: have test_type macros use the correct fieldname (DNA-3115 - DNA-3159)

### DIFF
--- a/macros/generic_tests/test_type_boolean.sql
+++ b/macros/generic_tests/test_type_boolean.sql
@@ -4,7 +4,7 @@ select *
 from Information_schema.Columns
 where Information_schema.Columns."TABLE_SCHEMA" = '{{ model.schema }}'
     and Information_schema.Columns."TABLE_NAME" = '{{ model.name }}'
-    and Information_schema.Columns."COLUMN_NAME" = '{{ column_name }}'
+    and Information_schema.Columns."COLUMN_NAME" = replace('{{ column_name }}', '"', '')
 {% if target.type == 'snowflake' %}
     and Information_schema.Columns."DATA_TYPE" <> 'BOOLEAN'
 {% elif target.type == 'sqlserver' %}

--- a/macros/generic_tests/test_type_date.sql
+++ b/macros/generic_tests/test_type_date.sql
@@ -4,7 +4,7 @@ select *
 from Information_schema.Columns
 where Information_schema.Columns."TABLE_SCHEMA" = '{{ model.schema }}'
     and Information_schema.Columns."TABLE_NAME" = '{{ model.name }}'
-    and Information_schema.Columns."COLUMN_NAME" = '{{ column_name }}'
+    and Information_schema.Columns."COLUMN_NAME" = replace('{{ column_name }}', '"', '')
     and lower(Information_schema.Columns."DATA_TYPE") <> 'date'
 
 {% endmacro %}

--- a/macros/generic_tests/test_type_double.sql
+++ b/macros/generic_tests/test_type_double.sql
@@ -4,7 +4,7 @@ select *
 from Information_schema.Columns
 where Information_schema.Columns."TABLE_SCHEMA" = '{{ model.schema }}'
     and Information_schema.Columns."TABLE_NAME" = '{{ model.name }}'
-    and Information_schema.Columns."COLUMN_NAME" = '{{ column_name }}'
+    and Information_schema.Columns."COLUMN_NAME" = replace('{{ column_name }}', '"', '')
     and lower(Information_schema.Columns."DATA_TYPE") <> 'float'
 
 {% endmacro %}

--- a/macros/generic_tests/test_type_integer.sql
+++ b/macros/generic_tests/test_type_integer.sql
@@ -4,7 +4,7 @@ select *
 from Information_schema.Columns
 where Information_schema.Columns."TABLE_SCHEMA" = '{{ model.schema }}'
     and Information_schema.Columns."TABLE_NAME" = '{{ model.name }}'
-    and Information_schema.Columns."COLUMN_NAME" = '{{ column_name }}'
+    and Information_schema.Columns."COLUMN_NAME" = replace('{{ column_name }}', '"', '')
 {% if target.type == 'snowflake' %}
     and Information_schema.Columns."DATA_TYPE" <> 'NUMBER'
 {% elif target.type == 'sqlserver' %}

--- a/macros/generic_tests/test_type_timestamp.sql
+++ b/macros/generic_tests/test_type_timestamp.sql
@@ -4,7 +4,7 @@ select *
 from Information_schema.Columns
 where Information_schema.Columns."TABLE_SCHEMA" = '{{ model.schema }}'
     and Information_schema.Columns."TABLE_NAME" = '{{ model.name }}'
-    and Information_schema.Columns."COLUMN_NAME" = '{{ column_name }}'
+    and Information_schema.Columns."COLUMN_NAME" = replace('{{ column_name }}', '"', '')
 {% if target.type == 'snowflake' %}
     and Information_schema.Columns."DATA_TYPE" <> 'TIMESTAMP_NTZ'
 {% elif target.type == 'sqlserver' %}


### PR DESCRIPTION
By default fieldnames are encapsulated in (extra) double quotes, these have to be removed