### PR TITLE
feat: string_agg only works with a maximum length of 2000 (DNA-6774: DNA-6981)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Usage:
 ```
 
 #### string_agg ([source](macros/multiple_databases/string_agg.sql))
-This macro aggregates string fields separated by the given delimiter. If no delimiter is specified, strings are separated by a comma followed by a space. This macro can only be used as an aggregate function.
+This macro aggregates string fields separated by the given delimiter. If no delimiter is specified, strings are separated by a comma followed by a space. This macro can only be used as an aggregate function. For SQL Server, the maximum supported length is 2000. 
 
 Usage:
 `{{ pm_utils.string_agg('[expression]', '[delimiter]') }}`

--- a/macros/multiple_databases/string_agg.sql
+++ b/macros/multiple_databases/string_agg.sql
@@ -10,9 +10,9 @@
     {%- endif -%}
 {%- elif target.type == 'sqlserver' -%}
     {%- if delimiter is defined -%}
-        string_agg(convert(nvarchar(max), {{ string_field}}), '{{ delimiter }}')
+        string_agg(convert(nvarchar(2000), {{ string_field}}), '{{ delimiter }}')
     {%- else -%}
-        string_agg(convert(nvarchar(max), {{ string_field}}), ', ')
+        string_agg(convert(nvarchar(2000), {{ string_field}}), ', ')
     {%- endif -%}
 {%- endif -%}
 


### PR DESCRIPTION
- String_agg function aggregates strings of type nvarchar(2000), which introduces the limitation that also the aggregate string has a maximum length 2000. This limitation should be acceptable.
- The variant macro still makes use internally of nvarchar(max), because when determining the variant IDs, the length may be more than 2000.