### PR TITLE
feat: support for user-friendly errors (DNA-9136: DNA-9580, DNA-9789)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This dbt package contains macros for SQL functions to run the dbt project on mul
   - [test_field_length](#test_field_length-source)
   - [test_format](#test_format-source)
   - [test_not_negative](#test_not_negative-source)
+  - [test_not_null](#test_not_null-source)
   - [test_one_column_not_null](#test_one_column_not_null-source)
   - [test_type_boolean](#test_type_boolean-source)
   - [test_type_date](#test_type_date-source)
@@ -56,6 +57,7 @@ This dbt package contains macros for SQL functions to run the dbt project on mul
   - [test_type_timestamp](#test_type_timestamp-source)
   - [test_type_varchar](#test_type_varchar-source)
   - [test_unique_combination_of_columns](#test_unique_combination_of_columns-source)
+  - [test_unique](#test_unique-source)
 - [Generic](#Generic)
   - [optional](#optional-source)
   - [left_from_char](#left_from_char-source)
@@ -116,6 +118,7 @@ This macro selects the minimum of the records in an aggregate expression for boo
 
 Usage:
 `{{ pm_utils.min_boolean('[expression]') }}`
+
 #### string_agg ([source](macros/multiple_databases/string_agg.sql))
 This macro aggregates string fields separated by the given delimiter. If no delimiter is specified, strings are separated by a comma followed by a space. This macro can only be used as an aggregate function. For SQL Server, the maximum supported length is 2000. 
 
@@ -226,7 +229,7 @@ models:
 ```
 
 #### test_field_length ([source](macros/generic_tests/test_field_length.sql))
-This generic test evaluates whether the values of the column have a particular length.
+This generic test evaluates whether the values of the column have a particular length. The test is only executed when the column exists on the table.
 
 Usage:
 ```
@@ -238,7 +241,7 @@ models:
 ```
 
 #### test_format ([source](macros/generic_tests/test_format.sql))
-This generic test evaluates whether the format of values of the column is as expected. Use this test on source tables to test the format of values before any transformation takes place. The test fails if at least one value has an incorrect format. Use the argument `data_type` to indicate the data type of the column. Possible values are: `date`, `time`, and `datetime`.
+This generic test evaluates whether the format of values of the column is as expected. Use this test on source tables to test the format of values before any transformation takes place. The test fails if at least one value has an incorrect format. Use the argument `data_type` to indicate the data type of the column. Possible values are: `date`, `time`, and `datetime`. The test is only executed when the column exists on the table.
 
 Usage:
 ```
@@ -264,8 +267,21 @@ models:
           - pm_utils.not_negative
 ```
 
+#### test_not_null ([source](macros/generic_tests/test_not_null.sql))
+This generic test evaluates whether the values of the column are not null. The test is only executed when the column exists on the table.
+
+Usage:
+```
+models:
+  - name: Model_A
+    columns:
+      - name: '"Column_A"'
+        tests:
+          - pm_utils.not_null
+```
+
 #### test_one_column_not_null ([source](macros/generic_tests/test_one_column_not_null.sql))
-This generic test evaluates whether exactly one out of the specified columns does contain a value. This test can be defined by two or more columns.
+This generic test evaluates whether exactly one out of the specified columns does contain a value. This test can be defined by two or more columns. The test is only executed when all columns exist on the table.
 
 Usage:
 ```
@@ -279,7 +295,7 @@ models:
 ```
 
 #### test_type_boolean ([source](macros/generic_tests/test_type_boolean.sql))
-This generic test evaluates whether a field is a boolean represented by the numeric values 0 and 1.
+This generic test evaluates whether a field is a boolean or bit data type depending on the database.
 
 Usage:
 ```
@@ -358,7 +374,7 @@ models:
 ```
 
 #### test_unique_combination_of_columns ([source](macros/generic_tests/test_unique_combination_of_columns.sql))
-This generic test evaluates whether the combination of columns is unique. This test can be defined by two or more columns.
+This generic test evaluates whether the combination of columns is unique. This test can be defined by two or more columns. The test is only executed when all columns exist on the table.
 
 Usage:
 ```
@@ -369,6 +385,19 @@ models:
           combination_of_columns:
             - 'Column_A'
             - 'Column_B'
+```
+
+#### test_unique ([source](macros/generic_tests/test_unique.sql))
+This generic test evaluates whether the values of the column are unique. The test is only executed when the column exists on the table.
+
+Usage:
+```
+models:
+  - name: Model_A
+    columns:
+      - name: '"Column_A"'
+        tests:
+          - pm_utils.unique
 ```
 
 ### Generic

--- a/macros/generic_tests/test_exists.sql
+++ b/macros/generic_tests/test_exists.sql
@@ -1,4 +1,4 @@
-{% macro test_exists(model, column_name) %}
+{% macro test_exists(model, column_name, name) %}
 
 {# Test fails if 0 records are returned. #}
 {{ config(fail_calc = 'case when count(*) = 0 then 1 else 0 end') }}

--- a/macros/generic_tests/test_field_length.sql
+++ b/macros/generic_tests/test_field_length.sql
@@ -1,4 +1,4 @@
-{% macro test_field_length(model, column_name, length) %}
+{% macro test_field_length(model, column_name, length, name) %}
 
 {% set exists_query %}
 select count(*) as "record_count"

--- a/macros/generic_tests/test_field_length.sql
+++ b/macros/generic_tests/test_field_length.sql
@@ -1,7 +1,32 @@
 {% macro test_field_length(model, column_name, length) %}
 
+{% set exists_query %}
+select count(*) as "record_count"
+from Information_schema.Columns
+where Information_schema.Columns."TABLE_SCHEMA" = '{{ model.schema }}'
+    and Information_schema.Columns."TABLE_NAME" = '{{ model.name }}'
+    and Information_schema.Columns."COLUMN_NAME" = replace('{{ column_name }}', '"', '')
+{% endset %}
+
+{# Execute the exists query. The record count is 1 if the field exists and 0 if it does not exist.#}
+{% set result_exists_query = run_query(exists_query) %}
+
+{# Get record count only when dbt is in execute mode to prevent compilation errors. #}
+{% if execute %}
+{% set record_count = result_exists_query.columns['record_count'].values()[0] %}
+{% else %}
+{% set record_count = 1 %}
+{% endif %}
+
+{# Only execute test when field exists. Otherwise execute a dummy test that always succeeds. #}
+{% if record_count > 0 %}
 select {{ column_name }}
 from {{ model }}
 where len({{ column_name }}) <> {{ length }}
+{% else %}
+select 'dummy_value' as "dummy"
+from {{ model }}
+where 1 = 0
+{% endif %}
 
 {% endmacro %}

--- a/macros/generic_tests/test_format.sql
+++ b/macros/generic_tests/test_format.sql
@@ -2,6 +2,26 @@
 
 {{ config(fail_calc = 'coalesce(diff_count, 0)') }}
 
+{% set exists_query %}
+select count(*) as "record_count"
+from Information_schema.Columns
+where Information_schema.Columns."TABLE_SCHEMA" = '{{ model.schema }}'
+    and Information_schema.Columns."TABLE_NAME" = '{{ model.name }}'
+    and Information_schema.Columns."COLUMN_NAME" = replace('{{ column_name }}', '"', '')
+{% endset %}
+
+{# Execute the exists query. The record count is 1 if the field exists and 0 if it does not exist.#}
+{% set result_exists_query = run_query(exists_query) %}
+
+{# Get record count only when dbt is in execute mode to prevent compilation errors. #}
+{% if execute %}
+{% set record_count = result_exists_query.columns['record_count'].values()[0] %}
+{% else %}
+{% set record_count = 1 %}
+{% endif %}
+
+{# Only execute test when field exists. Otherwise execute a dummy test that always succeeds. #}
+{% if record_count > 0 %}
 select
     abs(count_before_casting - count_after_casting) as diff_count
 from (
@@ -20,5 +40,10 @@ from (
         {%- elif data_type == 'datetime' -%}
         where {{ pm_utils.to_timestamp(column_name) }} is null) as model_after_casting
         {%- endif -%}
+{% else %}
+select 'dummy_value' as "dummy"
+from {{ model }}
+where 1 = 0
+{% endif %}
 
 {% endmacro %}

--- a/macros/generic_tests/test_format.sql
+++ b/macros/generic_tests/test_format.sql
@@ -1,4 +1,4 @@
-{% macro test_format(model, column_name, data_type) %}
+{% macro test_format(model, column_name, data_type, name) %}
 
 {{ config(fail_calc = 'coalesce(diff_count, 0)') }}
 

--- a/macros/generic_tests/test_not_null.sql
+++ b/macros/generic_tests/test_not_null.sql
@@ -1,0 +1,31 @@
+{% macro test_not_null(model, column_name) %}
+
+{% set exists_query %}
+select count(*) as "record_count"
+from Information_schema.Columns
+where Information_schema.Columns."TABLE_SCHEMA" = '{{ model.schema }}'
+    and Information_schema.Columns."TABLE_NAME" = '{{ model.name }}'
+    and Information_schema.Columns."COLUMN_NAME" = replace('{{ column_name }}', '"', '')
+{% endset %}
+
+{% set result_exists_query = run_query(exists_query) %}
+
+{# Execute the exists query. The result is 1 if the field exists and 0 if it does not exist. #}
+{% if execute %}
+{% set record_count = result_exists_query.columns['record_count'].values()[0] %}
+{% else %}
+{% set record_count = -1 %}
+{% endif %}
+
+{# Only execute test when field exists. Otherwise execute a dummy test that always returns 0 records. #}
+{% if record_count > 0 %}
+select {{ column_name }}
+from {{ model }}
+where {{ column_name }} is null
+{% else %}
+select 'dummy_value' as "dummy"
+from {{ model }}
+where 1 = 0
+{% endif %}
+
+{% endmacro %}

--- a/macros/generic_tests/test_not_null.sql
+++ b/macros/generic_tests/test_not_null.sql
@@ -1,4 +1,4 @@
-{% macro test_not_null(model, column_name) %}
+{% macro test_not_null(model, column_name, name) %}
 
 {% set exists_query %}
 select count(*) as "record_count"

--- a/macros/generic_tests/test_not_null.sql
+++ b/macros/generic_tests/test_not_null.sql
@@ -8,16 +8,17 @@ where Information_schema.Columns."TABLE_SCHEMA" = '{{ model.schema }}'
     and Information_schema.Columns."COLUMN_NAME" = replace('{{ column_name }}', '"', '')
 {% endset %}
 
+{# Execute the exists query. The record count is 1 if the field exists and 0 if it does not exist.#}
 {% set result_exists_query = run_query(exists_query) %}
 
-{# Execute the exists query. The result is 1 if the field exists and 0 if it does not exist. #}
+{# Get record count only when dbt is in execute mode to prevent compilation errors. #}
 {% if execute %}
 {% set record_count = result_exists_query.columns['record_count'].values()[0] %}
 {% else %}
-{% set record_count = -1 %}
+{% set record_count = 1 %}
 {% endif %}
 
-{# Only execute test when field exists. Otherwise execute a dummy test that always returns 0 records. #}
+{# Only execute test when field exists. Otherwise execute a dummy test that always succeeds. #}
 {% if record_count > 0 %}
 select {{ column_name }}
 from {{ model }}

--- a/macros/generic_tests/test_one_column_not_null.sql
+++ b/macros/generic_tests/test_one_column_not_null.sql
@@ -1,4 +1,4 @@
-{% macro test_one_column_not_null(model, columns) %}
+{% macro test_one_column_not_null(model, columns, name) %}
 
 {% set exists_query %}
 select count(*) as "record_count"

--- a/macros/generic_tests/test_one_column_not_null.sql
+++ b/macros/generic_tests/test_one_column_not_null.sql
@@ -1,5 +1,29 @@
 {% macro test_one_column_not_null(model, columns) %}
 
+{% set exists_query %}
+select count(*) as "record_count"
+from Information_schema.Columns
+where Information_schema.Columns."TABLE_SCHEMA" = '{{ model.schema }}'
+    and Information_schema.Columns."TABLE_NAME" = '{{ model.name }}'
+    and Information_schema.Columns."COLUMN_NAME" in (
+        {%- for column in columns -%}
+        '{{ column }}' {{',' if not loop.last }}
+        {%- endfor -%}
+    )
+{% endset %}
+
+{# Execute the exists query. The record count is the same as number of columns if all fields exist. #}
+{% set result_exists_query = run_query(exists_query) %}
+
+{# Get record count only when dbt is in execute mode to prevent compilation errors. #}
+{% if execute %}
+{% set record_count = result_exists_query.columns['record_count'].values()[0] %}
+{% else %}
+{% set record_count = columns|length %}
+{% endif %}
+
+{# Only execute test when fields exists. Otherwise execute a dummy test that always succeeds. #}
+{% if record_count == columns|length %}
 {% set column_list = [] %}
 {% for column in columns %}
     {% set column_list = column_list.append('case when "' + column + '" is not NULL then 1 else 0 end') %}
@@ -10,5 +34,10 @@
 select *
 from {{ model }}
 where {{ calculation }} <> 1
+{% else %}
+select 'dummy_value' as "dummy"
+from {{ model }}
+where 1 = 0
+{% endif %}
 
 {% endmacro %}

--- a/macros/generic_tests/test_unique.sql
+++ b/macros/generic_tests/test_unique.sql
@@ -1,4 +1,4 @@
-{% macro test_unique(model, column_name) %}
+{% macro test_unique(model, column_name, name) %}
 
 {% set exists_query %}
 select count(*) as "record_count"

--- a/macros/generic_tests/test_unique.sql
+++ b/macros/generic_tests/test_unique.sql
@@ -8,16 +8,17 @@ where Information_schema.Columns."TABLE_SCHEMA" = '{{ model.schema }}'
     and Information_schema.Columns."COLUMN_NAME" = replace('{{ column_name }}', '"', '')
 {% endset %}
 
+{# Execute the exists query. The record count is 1 if the field exists and 0 if it does not exist.#}
 {% set result_exists_query = run_query(exists_query) %}
 
-{# Execute the exists query. The result is 1 if the field exists and 0 if it does not exist. #}
+{# Get record count only when dbt is in execute mode to prevent compilation errors. #}
 {% if execute %}
 {% set record_count = result_exists_query.columns['record_count'].values()[0] %}
 {% else %}
-{% set record_count = -1 %}
+{% set record_count = 1 %}
 {% endif %}
 
-{# Only execute test when field exists. Otherwise execute a dummy test that always returns 0 records. #}
+{# Only execute test when field exists. Otherwise execute a dummy test that always succeeds. #}
 {% if record_count > 0 %}
 select {{ column_name }}
 from {{ model }}

--- a/macros/generic_tests/test_unique.sql
+++ b/macros/generic_tests/test_unique.sql
@@ -1,0 +1,32 @@
+{% macro test_unique(model, column_name) %}
+
+{% set exists_query %}
+select count(*) as "record_count"
+from Information_schema.Columns
+where Information_schema.Columns."TABLE_SCHEMA" = '{{ model.schema }}'
+    and Information_schema.Columns."TABLE_NAME" = '{{ model.name }}'
+    and Information_schema.Columns."COLUMN_NAME" = replace('{{ column_name }}', '"', '')
+{% endset %}
+
+{% set result_exists_query = run_query(exists_query) %}
+
+{# Execute the exists query. The result is 1 if the field exists and 0 if it does not exist. #}
+{% if execute %}
+{% set record_count = result_exists_query.columns['record_count'].values()[0] %}
+{% else %}
+{% set record_count = -1 %}
+{% endif %}
+
+{# Only execute test when field exists. Otherwise execute a dummy test that always returns 0 records. #}
+{% if record_count > 0 %}
+select {{ column_name }}
+from {{ model }}
+group by {{ column_name }}
+having count(*) > 1
+{% else %}
+select 'dummy_value' as "dummy"
+from {{ model }}
+where 1 = 0
+{% endif %}
+
+{% endmacro %}

--- a/macros/generic_tests/test_unique_combination_of_columns.sql
+++ b/macros/generic_tests/test_unique_combination_of_columns.sql
@@ -1,4 +1,4 @@
-{% macro test_unique_combination_of_columns(model, combination_of_columns) %}
+{% macro test_unique_combination_of_columns(model, combination_of_columns, name) %}
 
 {% set exists_query %}
 select count(*) as "record_count"

--- a/macros/generic_tests/test_unique_combination_of_columns.sql
+++ b/macros/generic_tests/test_unique_combination_of_columns.sql
@@ -1,5 +1,29 @@
 {% macro test_unique_combination_of_columns(model, combination_of_columns) %}
 
+{% set exists_query %}
+select count(*) as "record_count"
+from Information_schema.Columns
+where Information_schema.Columns."TABLE_SCHEMA" = '{{ model.schema }}'
+    and Information_schema.Columns."TABLE_NAME" = '{{ model.name }}'
+    and Information_schema.Columns."COLUMN_NAME" in (
+        {%- for column in combination_of_columns -%}
+        '{{ column }}' {{',' if not loop.last }}
+        {%- endfor -%}
+    )
+{% endset %}
+
+{# Execute the exists query. The record count is the same as number of columns if all fields exist. #}
+{% set result_exists_query = run_query(exists_query) %}
+
+{# Get record count only when dbt is in execute mode to prevent compilation errors. #}
+{% if execute %}
+{% set record_count = result_exists_query.columns['record_count'].values()[0] %}
+{% else %}
+{% set record_count = combination_of_columns|length %}
+{% endif %}
+
+{# Only execute test when fields exists. Otherwise execute a dummy test that always succeeds. #}
+{% if record_count == combination_of_columns|length %}
 {% set column_list = [] %}
 {% for column in combination_of_columns %}
     {% set column_list = column_list.append('"'+column+'"') %}
@@ -11,5 +35,10 @@ select {{ columns_csv }}
 from {{ model }}
 group by {{ columns_csv }}
 having count(*) > 1
+{% else %}
+select 'dummy_value' as "dummy"
+from {{ model }}
+where 1 = 0
+{% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
- Implement not_null and unique test.
- Include in tests that run on source data that the field should exist when running the test.
- Include optional dummy parameter 'name' to create compatibility with dbt v1.0.