### PR TITLE
refactor: use datetime2 instead of datetime in SQL Server DNA-11164 (DNA-12524)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'pm_utils'
-version: '0.11.0'
+version: '0.11.1'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/macros/generic_tests/test_type_timestamp.sql
+++ b/macros/generic_tests/test_type_timestamp.sql
@@ -8,7 +8,7 @@ where "INFORMATION_SCHEMA"."COLUMNS"."TABLE_SCHEMA" = '{{ model.schema }}'
 {% if target.type == 'snowflake' %}
     and "INFORMATION_SCHEMA"."COLUMNS"."DATA_TYPE" <> 'TIMESTAMP_NTZ'
 {% elif target.type == 'sqlserver' %}
-    and "INFORMATION_SCHEMA"."COLUMNS"."DATA_TYPE" <> 'datetime'
+    and "INFORMATION_SCHEMA"."COLUMNS"."DATA_TYPE" <> 'datetime2'
 {% endif %}
 
 {% endmacro %}

--- a/macros/multiple_databases/timestamp_from_date.sql
+++ b/macros/multiple_databases/timestamp_from_date.sql
@@ -3,14 +3,15 @@
 {%- if target.type == 'snowflake' -%}
     timestamp_from_parts({{ date_field }}, '0')
 {%- elif target.type == 'sqlserver' -%}
-    datetimefromparts(
+    datetime2fromparts(
         datepart(year, {{ date_field }}),
         datepart(month, {{ date_field }}),
         datepart(day, {{ date_field }}),
         0,
         0,
         0,
-        0
+        0,
+        3
     )
 {%- endif -%}
 

--- a/macros/multiple_databases/timestamp_from_parts.sql
+++ b/macros/multiple_databases/timestamp_from_parts.sql
@@ -3,14 +3,15 @@
 {%- if target.type == 'snowflake' -%}
     timestamp_from_parts({{ date_field }}, {{ time_field }})
 {%- elif target.type == 'sqlserver' -%}
-    datetimefromparts(
+    datetime2fromparts(
         datepart(year, {{ date_field }}),
         datepart(month, {{ date_field }}),
         datepart(day, {{ date_field }}),
         datepart(hour, {{ time_field }}),
         datepart(minute, {{ time_field }}),
         datepart(second, {{ time_field }}),
-        datepart(millisecond, {{ time_field }})
+        datepart(millisecond, {{ time_field }}),
+        3
     )
 {%- endif -%}
 

--- a/macros/multiple_databases/to_timestamp.sql
+++ b/macros/multiple_databases/to_timestamp.sql
@@ -3,7 +3,7 @@
 {%- if target.type == 'snowflake' -%}
     try_to_timestamp(to_varchar({{ field }}), '{{ var("datetime_format", "YYYY-MM-DD hh24:mi:ss.ff3") }}')
 {%- elif target.type == 'sqlserver' -%}
-    try_convert(datetime, {{ field }}, {{ var("datetime_format", 21) }})
+    try_convert(datetime2, {{ field }}, {{ var("datetime_format", 21) }})
 {%- endif -%}
 
 {%- endmacro -%}


### PR DESCRIPTION
Change `datetime` to `datetime2` datatypes with 3 digit precision in SQL Server.
Context: https://www.sqlines.com/sql-server/datetime_or_datetime2_3