### PR TITLE
DNA-14397  (DNA-14894) fix: put null in lowercase

### DIFF
--- a/macros/multiple_databases/date_from_timestamp.sql
+++ b/macros/multiple_databases/date_from_timestamp.sql
@@ -5,14 +5,14 @@
         when len({{ field }}) > 0
             then to_date({{ field }})
         else
-            to_date(NULL)
+            to_date(null)
     end
 {%- elif target.type == 'sqlserver' -%}
     case
         when len({{ field }}) > 0
             then try_convert(date, {{ field }})
         else
-            try_convert(date, NULL)
+            try_convert(date, null)
     end
 {%- endif -%}
 

--- a/macros/multiple_databases/timestamp_from_date.sql
+++ b/macros/multiple_databases/timestamp_from_date.sql
@@ -5,7 +5,7 @@
         when len({{ date_field }}) > 0
             then timestamp_from_parts({{ date_field }}, '0')
         else
-            timestamp_from_parts(NULL, NULL)
+            timestamp_from_parts(null, null)
     end
 {%- elif target.type == 'sqlserver' -%}
     case
@@ -22,13 +22,13 @@
                 )
         else
             datetime2fromparts(
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
                 3
             )
     end

--- a/macros/multiple_databases/timestamp_from_parts.sql
+++ b/macros/multiple_databases/timestamp_from_parts.sql
@@ -5,7 +5,7 @@
         when len({{ date_field }}) > 0 and len({{time_field}}) > 0
             then timestamp_from_parts({{ date_field }}, {{ time_field }})
         else
-            timestamp_from_parts(NULL, NULL)
+            timestamp_from_parts(null, null)
     end
 {%- elif target.type == 'sqlserver' -%}
     case
@@ -22,13 +22,13 @@
                 )
         else
             datetime2fromparts(
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
                 3
             )
     end

--- a/macros/multiple_databases/to_boolean.sql
+++ b/macros/multiple_databases/to_boolean.sql
@@ -14,7 +14,7 @@
             when len({{ field }}) > 0
                 then try_convert(bit, {{ field }})
             else
-                try_convert(bit, NULL)
+                try_convert(bit, null)
         end
     {%- endif -%}
 {%- endif -%}

--- a/macros/multiple_databases/to_date.sql
+++ b/macros/multiple_databases/to_date.sql
@@ -12,7 +12,7 @@
         when len({{ field }}) > 0
             then try_convert(date, {{ field }}, {{ var("date_format", 23) }})
         else
-            try_convert(date, NULL)
+            try_convert(date, null)
     end
 {%- endif -%}
 

--- a/macros/multiple_databases/to_double.sql
+++ b/macros/multiple_databases/to_double.sql
@@ -7,7 +7,7 @@
         when len({{ field }}) > 0
             then try_convert(float, {{ field }})
         else
-            try_convert(float, NULL)
+            try_convert(float, null)
     end
 {%- endif -%}
 

--- a/macros/multiple_databases/to_integer.sql
+++ b/macros/multiple_databases/to_integer.sql
@@ -7,7 +7,7 @@
         when len({{ field }}) > 0
             then try_convert(bigint, {{ field }})
         else
-             try_convert(bigint, NULL)
+             try_convert(bigint, null)
     end
 {%- endif -%}
 

--- a/macros/multiple_databases/to_time.sql
+++ b/macros/multiple_databases/to_time.sql
@@ -7,7 +7,7 @@
         when len({{ field }}) > 0
             then try_convert(time, {{ field }}, {{ var("time_format", 14) }})
         else
-            try_convert(time, NULL)
+            try_convert(time, null)
     end
 {%- endif -%}
 

--- a/macros/multiple_databases/to_timestamp.sql
+++ b/macros/multiple_databases/to_timestamp.sql
@@ -7,7 +7,7 @@
         when len({{ field }}) > 0
             then try_convert(datetime2, {{ field }}, {{ var("datetime_format", 21) }})
         else
-            try_convert(datetime2, NULL)
+            try_convert(datetime2, null)
     end
 {%- endif -%}
 


### PR DESCRIPTION
In the updates of the typecasting macros null was written in capital letters, set this to lower case for linting and consistency purposes. 