### PR TITLE
fix: inconsistency try_to_date and to_date to prevent unnecessary errors (DNA-14397: DNA-14909)

### DIFF
--- a/macros/multiple_databases/date_from_timestamp.sql
+++ b/macros/multiple_databases/date_from_timestamp.sql
@@ -3,9 +3,9 @@
 {%- if target.type == 'snowflake' -%}
     case
         when len({{ field }}) > 0
-            then to_date({{ field }})
+            then try_to_date({{ field }})
         else
-            to_date(null)
+            try_to_date(null)
     end
 {%- elif target.type == 'sqlserver' -%}
     case


### PR DESCRIPTION
Noticed an error with incorrect date format when trying to create an app with broken data. This results in an error with type casting, which we never want. 
Instead use "try_to.." which only gives a warning.