### PR TITLE
fix: date_from_timestamp requires varchar as input for try_to function (DNA-14397: DNA-15339)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'pm_utils'
-version: '0.14.0'
+version: '0.14.1'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/macros/multiple_databases/date_from_timestamp.sql
+++ b/macros/multiple_databases/date_from_timestamp.sql
@@ -1,9 +1,10 @@
 {%- macro date_from_timestamp(field) -%}
 
+{# Snowflake try_to function requires an expression of type varchar. #}
 {%- if target.type == 'snowflake' -%}
     case
         when len({{ field }}) > 0
-            then try_to_date({{ field }})
+            then try_to_date(to_varchar({{ field }}))
         else
             to_date(null)
     end

--- a/macros/multiple_databases/to_boolean.sql
+++ b/macros/multiple_databases/to_boolean.sql
@@ -1,5 +1,6 @@
 {%- macro to_boolean(field, relation) -%}
 
+{# Snowflake try_to function requires an expression of type varchar. #}
 {%- if target.type == 'snowflake' -%}
     {%- if field in ('true', 'false', '1', '0') -%}
         try_to_boolean('{{ field }}')

--- a/macros/multiple_databases/to_date.sql
+++ b/macros/multiple_databases/to_date.sql
@@ -1,6 +1,7 @@
 {%- macro to_date(field, relation) -%}
 
-{# Cast to date when the input is in a date or a datetime format. This is default behavior for SQL Server. #}
+{# Cast to date when the input is in a date or a datetime format. This is default behavior for SQL Server.
+Snowflake try_to function requires an expression of type varchar. #}
 {%- if target.type == 'snowflake' -%}
     case
         when try_to_date(to_varchar({{ field }}), '{{ var("date_format", "YYYY-MM-DD") }}') is null

--- a/macros/multiple_databases/to_double.sql
+++ b/macros/multiple_databases/to_double.sql
@@ -1,5 +1,6 @@
 {%- macro to_double(field, relation) -%}
 
+{# Snowflake try_to function requires an expression of type varchar. #}
 {%- if target.type == 'snowflake' -%}
     try_to_double(to_varchar({{ field }}))
 {%- elif target.type == 'sqlserver' -%}

--- a/macros/multiple_databases/to_integer.sql
+++ b/macros/multiple_databases/to_integer.sql
@@ -1,5 +1,6 @@
 {%- macro to_integer(field, relation) -%}
 
+{# Snowflake try_to function requires an expression of type varchar. #}
 {%- if target.type == 'snowflake' -%}
     try_to_number(to_varchar({{ field }}))
 {%- elif target.type == 'sqlserver' -%}

--- a/macros/multiple_databases/to_time.sql
+++ b/macros/multiple_databases/to_time.sql
@@ -1,5 +1,6 @@
 {%- macro to_time(field, relation) -%}
 
+{# Snowflake try_to function requires an expression of type varchar. #}
 {%- if target.type == 'snowflake' -%}
     try_to_time(to_varchar({{ field }}), '{{ var("time_format", "hh24:mi:ss.ff3") }}')
 {%- elif target.type == 'sqlserver' -%}

--- a/macros/multiple_databases/to_timestamp.sql
+++ b/macros/multiple_databases/to_timestamp.sql
@@ -1,5 +1,6 @@
 {%- macro to_timestamp(field, relation) -%}
 
+{# Snowflake try_to function requires an expression of type varchar. #}
 {%- if target.type == 'snowflake' -%}
     try_to_timestamp(to_varchar({{ field }}), '{{ var("datetime_format", "YYYY-MM-DD hh24:mi:ss.ff3") }}')
 {%- elif target.type == 'sqlserver' -%}


### PR DESCRIPTION
- The try_to_date function in the date_from_timestamp requires a string as input before casting to date can be done.
- This will be released as a bug fix together with https://github.com/UiPath/ProcessMining-pm-utils/pull/50. So update to version 0.14.1.