### PR TITLE
fix: optional field on optional tables DNA-15851

### DIFF
--- a/macros/generic/optional.sql
+++ b/macros/generic/optional.sql
@@ -1,6 +1,12 @@
 {%- macro optional(relation, optional_column, data_type) -%}
 
-{%- set columns = adapter.get_columns_in_relation(relation) -%}
+{# When the relation is not defined (optional tables), set the columns and relation to empty #}
+{%- if load_relation(relation) is none -%}
+    {%- set columns = [] -%}
+    {%- set relation = null -%}
+{%- else -%}
+    {%- set columns = adapter.get_columns_in_relation(relation) -%}
+{%- endif -%}
 
 {# Create list of column names.#}
 {%- set column_names = [] -%}


### PR DESCRIPTION
In the `optional` macro we assumed the `relation` always exists. This did not work for optional tables. Added functionality to deal with this.

Tested:
- Source table does not exist.
- Source table does exist, but field does not exist.
- Source table does exist and field does exist.
- Source table is mandatory, but field is optional (and exists) 