### PR TITLE
fix: make string_agg consistent when aggregating null values (DNA-16185: DNA-17242)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'pm_utils'
-version: '0.14.2'
+version: '0.14.3'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/macros/multiple_databases/string_agg.sql
+++ b/macros/multiple_databases/string_agg.sql
@@ -10,9 +10,9 @@
     {%- endif -%}
 {%- elif target.type == 'sqlserver' -%}
     {%- if delimiter is defined -%}
-        string_agg(convert(nvarchar(2000), {{ string_field}}), '{{ delimiter }}')
+        nullif(string_agg(convert(nvarchar(2000), {{ string_field}}), '{{ delimiter }}'), '')
     {%- else -%}
-        string_agg(convert(nvarchar(2000), {{ string_field}}), ', ')
+        nullif(string_agg(convert(nvarchar(2000), {{ string_field}}), ', '), '')
     {%- endif -%}
 {%- endif -%}
 

--- a/macros/multiple_databases/string_agg.sql
+++ b/macros/multiple_databases/string_agg.sql
@@ -4,9 +4,9 @@
    This function can only be used as an aggregate. #}
 {%- if target.type == 'snowflake' -%}
     {%- if delimiter is defined -%}
-        listagg({{ string_field }}, '{{ delimiter }}')
+        nullif(listagg({{ string_field }}, '{{ delimiter }}'), '')
     {%- else -%}
-        listagg({{ string_field }}, ', ')
+        nullif(listagg({{ string_field }}, ', '), '')
     {%- endif -%}
 {%- elif target.type == 'sqlserver' -%}
     {%- if delimiter is defined -%}


### PR DESCRIPTION
## Description
- Make string_agg consistent to output null instead of the empty string in Snowflake when string_agg is applied on only null values.

## Release
- [x] Direct release (`main`)
- [ ] Merge to `dev` (or other) branch
  - Why:

Merge to main, but release will be done later.

### Did you consider?
- [x] Does it Work on Automation Suite / SQL Server
- [x] Does it Work on Automation Cloud / Snowflake
- [x] What is the performance impact?
- [x] The version number in `dbt_project.yml`
