### PR TITLE
fix: optional without casting (DNA-18184: DNA-18273)

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ You can also set `id` as data type, which creates the column with unique integer
 Usage:
 `{{ pm_utils.optional(source('source_name', 'table_name'), '"Column_A"', 'data_type') }}`
 
-Alternatively, you can use this macro for non-source data. Use instead of the source function, the ref function: `ref(table_name)`.
+Alternatively, you can use this macro for non-source data. Use instead of the source function the ref function: `ref(table_name)`. In that case, data type casting is not applied.
 
 To keep the SQL in the model more readable, you can define a Jinja variable for the reference to the source table:
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'pm_utils'
-version: '0.14.3'
+version: '0.14.4'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/macros/generic/optional.sql
+++ b/macros/generic/optional.sql
@@ -33,7 +33,7 @@
 {%- endif -%}
 
 {# Apply casting when relation is a source or when the field doesn't exist in the relation and is being created. #}
-{% if ns.is_source_relation or column_value == 'null'%}
+{% if ns.is_source_relation or column_value == 'null' %}
     {%- if data_type == 'boolean' -%}
         {{ pm_utils.to_boolean(column_value, relation) }}
     {%- elif data_type == 'date' -%}


### PR DESCRIPTION
## Description
- Update the optional() implementation to prevent data type casting on a field that can be selected when relation is not a source. 
- This is to prevent potential 2nd data type casting on already casted fields. 2nd data type casting is a problem for date, time, and datetime fields when a format variable is provided different from the database standard (Snowflake only).

## Release
- [x] Direct release (`main`)
- [ ] Merge to `dev` (or other) branch
  - Why:

### Did you consider?
- [x] Does it Work on Automation Suite / SQL Server
- [x] Does it Work on Automation Cloud / Snowflake
- [x] What is the performance impact?
- [x] The version number in `dbt_project.yml`
