### PR TITLE
Enable databricks casting, mandatory and optional macros DNA-17332 [DNA-17608 + DNA-17635]

### DIFF
--- a/macros/generic/optional.sql
+++ b/macros/generic/optional.sql
@@ -22,7 +22,11 @@
 {# Create list of column names.#}
 {%- set column_names = [] -%}
 {%- for column in columns -%}
-    {%- set column_names = column_names.append('"' + column.name + '"') -%}
+    {%- if target.type == 'databricks' -%}
+        {%- set column_names = column_names.append('`' + column.name + '`') -%}
+    {%- elif target.type in ('sqlserver', 'snowflake') -%}
+        {%- set column_names = column_names.append('"' + column.name + '"') -%}
+    {% endif %}
 {%- endfor -%}
 
 {# When the column is in the list, use the column, otherwise create the column with null values.#}

--- a/macros/generic/optional_table.sql
+++ b/macros/generic/optional_table.sql
@@ -10,7 +10,9 @@
     {{ source_table }}
 {%- else -%}
     {% set query %}
-        {% if target.type == 'snowflake' %}
+        {% if target.type == 'databricks' %}
+            create or replace table `{{ target.database }}`.`{{ target.schema }}`.`{{ source_table.name }}` (dummy int)
+        {% elif target.type == 'snowflake' %}
             create or replace table "{{ target.database }}"."{{ target.schema }}"."{{ source_table.name }}" (dummy int)
         {% elif target.type == 'sqlserver' %}
             if object_id('"{{ target.database }}"."{{ target.schema }}"."{{ source_table.name }}"', 'U') is null
@@ -19,7 +21,11 @@
     {% endset %}
 
     {% do run_query(query) %}
-    "{{ target.database }}"."{{ target.schema }}"."{{ source_table.name }}"
+    {% if target.type == 'databricks' %}
+        `{{ target.database }}`.`{{ target.schema }}`.`{{ source_table.name }}`
+    {% elif target.type in ('snowflake', 'sqlserver') %}
+        "{{ target.database }}"."{{ target.schema }}"."{{ source_table.name }}"
+    {% endif %}
 {%- endif -%}
 
 {%- endmacro -%}

--- a/macros/multiple_databases/as_varchar.sql
+++ b/macros/multiple_databases/as_varchar.sql
@@ -1,6 +1,8 @@
 {%- macro as_varchar(field) -%}
 
-{%- if target.type == 'snowflake' -%}
+{%- if target.type == 'databricks' -%}
+    cast('{{ field }}' as string)
+{%- elif target.type == 'snowflake' -%}
     to_varchar('{{ field }}')
 {%- elif target.type == 'sqlserver' -%}
     convert(nvarchar(2000), '{{ field }}')

--- a/macros/multiple_databases/to_boolean.sql
+++ b/macros/multiple_databases/to_boolean.sql
@@ -1,7 +1,13 @@
 {%- macro to_boolean(field, relation) -%}
 
+{%- if target.type == 'databricks' -%}
+    {%- if field in ('true', 'false', '1', '0') -%}
+        try_cast('{{ field }}' as boolean)
+    {%- else -%}
+        try_cast({{ field }} as boolean)
+    {%- endif -%}
 {# Snowflake try_to function requires an expression of type varchar. #}
-{%- if target.type == 'snowflake' -%}
+{%- elif target.type == 'snowflake' -%}
     {%- if field in ('true', 'false', '1', '0') -%}
         try_to_boolean('{{ field }}')
     {%- else -%}
@@ -23,11 +29,23 @@
 {# Warning if type casting will introduce null values for at least 1 record. #}
 {% if relation is defined %}
     {% set query %}
+    {% if target.type == 'databricks' -%}
+    select
+        count(*) as `record_count`
+    from `{{ relation.database }}`.`{{ relation.schema }}`.`{{ relation.identifier }}`
+    {%- elif target.type in ('sqlserver', 'snowflake') -%}
     select
         count(*) as "record_count"
     from "{{ relation.database }}"."{{ relation.schema }}"."{{ relation.identifier }}"
+    {%- endif -%}
     where {{ field }} is not null and
-        {% if target.type == 'snowflake' -%}
+        {% if target.type == 'databricks' -%}
+            {%- if field in ('true', 'false', '1', '0') -%}
+                try_cast('{{ field }}' as boolean) is null
+            {%- else -%}
+                try_cast({{ field }} as boolean) is null
+            {%- endif -%}
+        {% elif target.type == 'snowflake' -%}
             {%- if field in ('true', 'false', '1', '0') -%}
                 try_to_boolean('{{ field }}') is null
             {%- else -%}

--- a/macros/multiple_databases/to_double.sql
+++ b/macros/multiple_databases/to_double.sql
@@ -1,7 +1,9 @@
 {%- macro to_double(field, relation) -%}
 
 {# Snowflake try_to function requires an expression of type varchar. #}
-{%- if target.type == 'snowflake' -%}
+{%- if target.type == 'databricks' -%}
+    try_cast({{ field }} as float)
+{%- elif target.type == 'snowflake' -%}
     try_to_double(to_varchar({{ field }}))
 {%- elif target.type == 'sqlserver' -%}
     case
@@ -15,11 +17,19 @@
 {# Warning if type casting will introduce null values for at least 1 record. #}
 {% if relation is defined %}
     {% set query %}
+    {% if target.type == 'databricks' -%}
+    select
+        count(*) as `record_count`
+    from `{{ relation.database }}`.`{{ relation.schema }}`.`{{ relation.identifier }}`
+    {%- elif target.type in ('sqlserver', 'snowflake') -%}
     select
         count(*) as "record_count"
     from "{{ relation.database }}"."{{ relation.schema }}"."{{ relation.identifier }}"
+    {% endif %}
     where {{ field }} is not null and
-        {% if target.type == 'snowflake' -%}
+        {% if target.type == 'databricks' -%}
+            try_cast({{ field }} as float) is null
+        {% elif target.type == 'snowflake' -%}
             try_to_double(to_varchar({{ field }})) is null
         {% elif target.type == 'sqlserver' -%}
             case

--- a/macros/multiple_databases/to_integer.sql
+++ b/macros/multiple_databases/to_integer.sql
@@ -1,25 +1,35 @@
 {%- macro to_integer(field, relation) -%}
 
 {# Snowflake try_to function requires an expression of type varchar. #}
-{%- if target.type == 'snowflake' -%}
+{%- if target.type == 'databricks' -%}
+    try_cast({{ field }} as bigint)
+{%- elif target.type == 'snowflake' -%}
     try_to_number(to_varchar({{ field }}))
 {%- elif target.type == 'sqlserver' -%}
     case
         when len({{ field }}) > 0
             then try_convert(bigint, {{ field }})
         else
-             try_convert(bigint, null)
+            try_convert(bigint, null)
     end
 {%- endif -%}
 
 {# Warning if type casting will introduce null values for at least 1 record. #}
 {% if relation is defined %}
     {% set query %}
+    {% if target.type == 'databricks' -%}
+    select
+        count(*) as `record_count`
+    from `{{ relation.database }}`.`{{ relation.schema }}`.`{{ relation.identifier }}`
+    {%- elif target.type in ('sqlserver', 'snowflake') -%}
     select
         count(*) as "record_count"
     from "{{ relation.database }}"."{{ relation.schema }}"."{{ relation.identifier }}"
+    {% endif %}
     where {{ field }} is not null and
-        {% if target.type == 'snowflake' -%}
+        {% if target.type == 'databricks' -%}
+            try_cast({{ field }} as bigint) is null
+        {% elif target.type == 'snowflake' -%}
             try_to_number(to_varchar({{ field }})) is null
         {% elif target.type == 'sqlserver' -%}
             case

--- a/macros/multiple_databases/to_varchar.sql
+++ b/macros/multiple_databases/to_varchar.sql
@@ -1,13 +1,15 @@
 {%- macro to_varchar(field) -%}
 
-{%- if target.type == 'snowflake' -%}
+{%- if target.type == 'databricks' -%}
+    cast({{ field }} as string)
+{%- elif target.type == 'snowflake' -%}
     to_varchar({{ field }})
 {%- elif target.type == 'sqlserver' -%}
     case
         when charindex(' ', {{ field }}) > 0
             then convert(nvarchar(2000), {{ field }})
         else
-            nullif(convert(nvarchar(2000), {{ field }}),'')
+            nullif(convert(nvarchar(2000), {{ field }}), '')
     end
 {%- endif -%}
 


### PR DESCRIPTION
## Description
- Mandatory and optional macro's are enabled for Databricks
- Casting macro's that are implemented for Databricks: `to_boolean`, `to_date`, `to_double`, `to_int`, `to_timestamp`, `to_varchar`, `as_varchar`
- Documentation to be done in separate PR.

## Release
- [ ] Direct release (`main`)
- [x] Merge to `dev` (or other) branch
  - Why: Merge to dev branch designated for Databricks. We will merge to main once this is completely implemented.

### Did you consider?
- [ ] ~~Does it Work on Automation Suite / SQL Server~~
- [ ] ~~Does it Work on Automation Cloud / Snowflake~~
- [ ] ~~What is the performance impact?~~
- [ ] ~~The version number in `dbt_project.yml`~~
