### PR TITLE
Implemented time related macro's for databricks DNA-17332 [DNA-18809]

### DIFF
--- a/macros/multiple_databases/date_from_timestamp.sql
+++ b/macros/multiple_databases/date_from_timestamp.sql
@@ -15,6 +15,8 @@
         else
             try_convert(date, null)
     end
+{%- elif target.type == 'databricks' -%}
+    to_date({{ field }})
 {%- endif -%}
 
 {%- endmacro -%}

--- a/macros/multiple_databases/datediff.sql
+++ b/macros/multiple_databases/datediff.sql
@@ -4,6 +4,21 @@
     datediff({{ datepart }}, {{ start_date_field }}, {{ end_date_field }})
 {%- elif target.type == 'sqlserver' -%}
     datediff_big({{ datepart }}, {{ start_date_field }}, {{ end_date_field }})
+{%- elif target.type == 'databricks' -%}
+    {%- if datepart == 'millisecond' -%}
+        unix_millis(to_timestamp({{ end_date_field }})) - unix_millis(to_timestamp({{ start_date_field }}))
+    {%- elif datepart == 'second' -%}
+        unix_seconds(to_timestamp({{ end_date_field }})) - unix_seconds(to_timestamp({{ start_date_field }}))
+    {%- elif datepart == 'minute' -%}
+        bigint((unix_seconds(to_timestamp({{ end_date_field }})) - unix_seconds(to_timestamp({{ start_date_field }})))/60)
+    {%- elif datepart == 'hour' -%}
+        bigint((unix_seconds(to_timestamp({{ end_date_field }})) - unix_seconds(to_timestamp({{ start_date_field }})))/3600)
+    {%- elif datepart == 'day' -%}
+        bigint(datediff({{ end_date_field }}, {{ start_date_field }}))
+    {%- elif datepart == 'year' -%}
+        bigint(year({{ end_date_field }}) - year({{ start_date_field }}))
+    {%- endif -%}
+ 
 {%- endif -%}
 
 {%- endmacro -%}

--- a/macros/multiple_databases/timestamp_from_date.sql
+++ b/macros/multiple_databases/timestamp_from_date.sql
@@ -32,6 +32,8 @@
                 3
             )
     end
+{%- elif target.type == 'databricks' -%}
+    date_trunc('DD', {{ date_field }})
 {%- endif -%}
 
 {%- endmacro -%}

--- a/macros/multiple_databases/timestamp_from_parts.sql
+++ b/macros/multiple_databases/timestamp_from_parts.sql
@@ -32,6 +32,13 @@
                 3
             )
     end
+{%- elif target.type == 'databricks' -%}
+    case
+        when length({{ date_field }}) > 0 and length({{time_field}}) > 0
+            then timestamp_millis(bigint(bigint(unix_date({{ date_field }})) * 86400000) + unix_millis({{ time_field }}))
+        else
+            to_timestamp(null)
+    end
 {%- endif -%}
 
 {%- endmacro -%}


### PR DESCRIPTION
## Description
- Implemented Databricks variant for the following macro's: `datediff`, `date_from_timestamp`, `timestamp_from_date`, `timestamp_from_parts`
- `datediff` implements all units of time as for SQL Server or Snowflake, but there are differences when it comes to rounding. F.e. for weeks, the difference between `2017-11-21` and `2017-11-01` in Snowflake is 3, whereas in Databricks, it is 2, regardless whether the implementation is done using date differences or unix seconds.

## Release
- [ ] Direct release (`main`)
- [x] Merge to `dev` (or other) branch
  - Why: Merge to databricks branch

### Did you consider?
- [ ] ~~Does it Work on Automation Suite / SQL Server~~
- [ ] ~~Does it Work on Automation Cloud / Snowflake~~
- [ ] ~~What is the performance impact?~~
- [ ] ~~The version number in `dbt_project.yml`~~
