### PR TITLE
fix: datadiff week inconsistency between SQL Server and Snowflake (DNA-17332 / DNA-19251)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Usage:
 `{{ pm_utils.date_from_timestamp('[expression]') }}`
 
 #### datediff ([source](macros/multiple_databases/datediff.sql))
-This macro computes the difference between two date, time, or datetime expressions based on the specified `datepart` and returns an integer value. The datepart can be any of the following values: year, quarter, month, week, day, hour, minute, second, millisecond.
+This macro computes the difference between two date, time, or datetime expressions based on the specified `datepart` and returns an integer value. The datepart can be any of the following values: year, quarter, month, week, day, hour, minute, second, millisecond. The difference in weeks is calculated for weeks starting on Monday.
 
 Usage: 
 `{{ pm_utils.datediff('[datepart]', '[start_date_expression]', '[end_date_expression]') }}`

--- a/macros/multiple_databases/datediff.sql
+++ b/macros/multiple_databases/datediff.sql
@@ -3,7 +3,12 @@
 {%- if target.type == 'snowflake' -%}
     datediff({{ datepart }}, {{ start_date_field }}, {{ end_date_field }})
 {%- elif target.type == 'sqlserver' -%}
-    datediff_big({{ datepart }}, {{ start_date_field }}, {{ end_date_field }})
+    {%- if datepart == 'week' -%}
+        {# To calculate week differences, weeks start by default on Sunday. Change to align with Snowflake (week starts on Monday) #}
+        datediff_big({{ datepart }}, dateadd(day, -1, {{ start_date_field }}), dateadd(day, -1, {{ end_date_field }}))
+    {%- else -%}
+        datediff_big({{ datepart }}, {{ start_date_field }}, {{ end_date_field }})
+    {%- endif -%}
 {%- endif -%}
 
 {%- endmacro -%}


### PR DESCRIPTION
## Description
- The output for datediff using week as datepart is not the same for SQL Server and Snowflake. The difference is caused because Snowflake and SQL Server use a different day as start of the week, for Snowflake this is Monday, for SQL Server this is Sunday. This fix aligns both (week starting on Monday).

## Release
- [X] Direct release (`main`)
- [ ] Merge to `dev` (or other) branch
  - Why:

### Did you consider?
- [X] Does it Work on Automation Suite / SQL Server
- [X] Does it Work on Automation Cloud / Snowflake
~~- [ ] What is the performance impact?~~
- [ ] The version number in `dbt_project.yml`
    - We will release this together with the next update for pm_utils
