### PR TITLE
Remove unused time option for mandatory/optional macro's DNA-17332 [DNA-19289]

### DIFF
--- a/macros/generic/mandatory.sql
+++ b/macros/generic/mandatory.sql
@@ -8,8 +8,6 @@
     {{ pm_utils.to_double(mandatory_column, relation) }}
 {%- elif data_type == 'integer' -%}
     {{ pm_utils.to_integer(mandatory_column, relation) }}
-{%- elif data_type == 'time' -%}
-    {{ pm_utils.to_time(mandatory_column, relation) }}
 {%- elif data_type == 'datetime' -%}
     {{ pm_utils.to_timestamp(mandatory_column, relation) }}
 {%- elif data_type == 'text' -%}

--- a/macros/generic/optional.sql
+++ b/macros/generic/optional.sql
@@ -47,8 +47,6 @@ Only check when relation exists to prevent dbt compile errors. #}
         {{ pm_utils.to_double(column_value, relation) }}
     {%- elif data_type == 'integer' -%}
         {{ pm_utils.to_integer(column_value, relation) }}
-    {%- elif data_type == 'time' -%}
-        {{ pm_utils.to_time(column_value, relation) }}
     {%- elif data_type == 'datetime' -%}
         {{ pm_utils.to_timestamp(column_value, relation) }}
     {%- elif data_type == 'text' -%}


### PR DESCRIPTION
## Description
- Remove unused time option for mandatory/optional macro's since the to_time macro is no longer available.

## Release
- [ ] Direct release (`main`)
- [x ] Merge to `dev` (or other) branch
  - Why: Merge to Databricks dev branch

### Did you consider?
- [ ] ~~Does it Work on Automation Suite / SQL Server~~
- [ ] ~~Does it Work on Automation Cloud / Snowflake~~
- [ ] ~~What is the performance impact?~~
- [ ] ~~The version number in `dbt_project.yml`~~
