### PR TITLE
Refactor timestamp_from_parts to accept time as string DNA-17332 [DNA-17615]

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ vars:
   # Date and time formats.
   # For SQL Server defined by integers and for Snowflake/Databricks defined by strings.
   date_format: 23     # default: SQL Server: 23, Snowflake: 'YYYY-MM-DD', Databricks: 'yyyy-MM-dd'
+  time_format: 14     # default: SQL Server: 14, Snowflake: 'hh24:mi:ss.ff3', Databricks: 'HH:mm:ss[.SSS]'
   datetime_format: 21 # default: SQL Server: 21, Snowflake: 'YYYY-MM-DD hh24:mi:ss.ff3', Databricks: 'yyyy-MM-dd HH:mm:ss[.SSS]'
 ```
 
@@ -109,7 +110,10 @@ Usage:
 `{{ pm_utils.timestamp_from_date('[expression]') }}`
 
 #### timestamp_from_parts ([source](macros/multiple_databases/timestamp_from_parts.sql))
-This macro create a timestamp based on a date and time field for SQL Server and Snowflake. For Databricks, the macro accepts two datetime fields, where the first field contains only the date and the second field only the time.
+This macro creates a timestamp based on a date field and string containing the time field.
+
+Variables:
+- time_format
 
 Usage: 
 `{{ pm_utils.timestamp_from_parts('[date_expression]', '[time_expression]') }}`

--- a/macros/multiple_databases/timestamp_from_parts.sql
+++ b/macros/multiple_databases/timestamp_from_parts.sql
@@ -2,8 +2,8 @@
 
 {%- if target.type == 'snowflake' -%}
     case
-        when len({{ date_field }}) > 0 and len({{time_field}}) > 0
-            then timestamp_from_parts({{ date_field }}, {{ time_field }})
+        when len({{ date_field }}) > 0 and len({{ time_field }}) > 0
+            then timestamp_from_parts({{ date_field }}, try_to_time({{ time_field }}, '{{ var("time_format", "hh24:mi:ss.ff3") }}'))
         else
             timestamp_from_parts(null, null)
     end
@@ -14,10 +14,10 @@
                     datepart(year, {{ date_field }}),
                     datepart(month, {{ date_field }}),
                     datepart(day, {{ date_field }}),
-                    datepart(hour, {{ time_field }}),
-                    datepart(minute, {{ time_field }}),
-                    datepart(second, {{ time_field }}),
-                    datepart(millisecond, {{ time_field }}),
+                    datepart(hour, try_convert(time, {{ time_field }}, {{ var("time_format", 14) }})),
+                    datepart(minute, try_convert(time, {{ time_field }}, {{ var("time_format", 14) }})),
+                    datepart(second, try_convert(time, {{ time_field }}, {{ var("time_format", 14) }})),
+                    datepart(millisecond, try_convert(time, {{ time_field }}, {{ var("time_format", 14) }})),
                     3
                 )
         else
@@ -34,8 +34,8 @@
     end
 {%- elif target.type == 'databricks' -%}
     case
-        when length({{ date_field }}) > 0 and length({{time_field}}) > 0
-            then timestamp_millis(bigint(bigint(unix_date({{ date_field }})) * 86400000) + unix_millis({{ time_field }}))
+        when length({{ date_field }}) > 0 and length({{ time_field }}) > 0
+            then timestamp_millis(bigint(bigint(unix_date({{ date_field }})) * 86400000) + unix_millis(try_to_timestamp({{ time_field }}, '{{ var("time_format", "HH:mm:ss[.SSS]") }}')))
         else
             to_timestamp(null)
     end


### PR DESCRIPTION
## Description
- Refactor `timestamp_from_parts` to accept strings for the time field. This reintroduces the usage of the `time_format` variable in `dbt_project.yml`

## Release
- [ ] Direct release (`main`)
- [x] Merge to `dev` (or other) branch
  - Why: Merge to Databricks dev branch

### Did you consider?
- [x] Does it Work on Automation Suite / SQL Server
- [x] Does it Work on Automation Cloud / Snowflake
- [ ] ~~What is the performance impact?~~
- [ ] ~~The version number in `dbt_project.yml`~~
