### PR TITLE
fix: cast to_double for Databricks to double DNA-15944 (DNA-20110)

### DIFF
--- a/macros/multiple_databases/to_double.sql
+++ b/macros/multiple_databases/to_double.sql
@@ -2,7 +2,7 @@
 
 {# Snowflake try_to function requires an expression of type varchar. #}
 {%- if target.type == 'databricks' -%}
-    try_cast({{ field }} as float)
+    try_cast({{ field }} as double)
 {%- elif target.type == 'snowflake' -%}
     try_to_double(to_varchar({{ field }}))
 {%- elif target.type == 'sqlserver' -%}


### PR DESCRIPTION
## Description
The `to_double` function was casting to `float` for databricks, which we changed to `double`, since:

- Databricks defaults to type `double` when applying f.e. multiplications on a `float` value
- Precision of `float` is different compared to what SQL Server does

## Release
- [ ] Direct release (`main`)
- [x] Merge to `dev` (or other) branch
  - Why: part of the databricks development

### Did you consider?
- [x] Does it Work on Automation Suite / SQL Server
- [x] Does it Work on Automation Cloud / Snowflake
- [x] What is the performance impact?
~~- [ ] The version number in `dbt_project.yml`~~ Still on dev branch
