### PR TITLE
Handle milliseconds in timestamp_from_parts for Databricks DNA-15944 [DNA-20489]

### DIFF
--- a/macros/multiple_databases/timestamp_from_parts.sql
+++ b/macros/multiple_databases/timestamp_from_parts.sql
@@ -35,9 +35,14 @@
 {%- elif target.type == 'databricks' -%}
     case
         when length({{ date_field }}) > 0 and length({{ time_field }}) > 0
-            then timestamp_millis(bigint(bigint(unix_date({{ date_field }})) * 86400000) + unix_millis(try_to_timestamp({{ time_field }}, '{{ var("time_format", "HH:mm:ss[.SSS]") }}')))
-        else
-            to_timestamp(null)
+            then
+                case
+                    when try_to_timestamp({{ time_field }}, '{{ var("time_format", "HH:mm:ss") }}.SSS') is null
+                        then timestamp_millis(bigint(bigint(unix_date({{ date_field }})) * 86400000) + unix_millis(try_to_timestamp({{ time_field }}, '{{ var("time_format", "HH:mm:ss") }}')))
+                    else timestamp_millis(bigint(bigint(unix_date({{ date_field }})) * 86400000) + unix_millis(try_to_timestamp({{ time_field }}, '{{ var("time_format", "HH:mm:ss") }}.SSS')))
+                end
+            else
+                to_timestamp(null)
     end
 {%- endif -%}
 


### PR DESCRIPTION
## Description
- Implement manual fallback for milliseconds usage in time formats due to the legacy time parser setting for Databricks.

## Release
- [ ] Direct release (`main`)
- [x] Merge to `dev` (or other) branch
  - Why: Merge to Databricks branch

### Did you consider?
- [ ] ~~Does it Work on Automation Suite / SQL Server~~
- [x] Does it Work on Automation Cloud / Snowflake
- [ ] ~~What is the performance impact?~~
- [ ] ~~The version number in `dbt_project.yml`~~
