### PR TITLE
fix: cast number param for dateadd to int for databricks DNA-15944 (DNA-20849)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'pm_utils'
-version: '1.0.0'
+version: '1.1.1'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/macros/multiple_databases/dateadd.sql
+++ b/macros/multiple_databases/dateadd.sql
@@ -4,6 +4,9 @@
 {%- elif target.type == 'sqlserver' -%}
     dateadd({{ datepart }}, {{ number }}, try_convert(datetime2, {{ date_or_datetime_field }}))
 {%- elif target.type == 'databricks' -%}
+    {%- set number_int -%}
+        try_cast({{ number }} as INT)
+    {%- endset -%}
     {%- set datetime_field -%}
         try_to_timestamp({{ date_or_datetime_field }})
     {%- endset -%}
@@ -11,23 +14,23 @@
         unix_millis({{ datetime_field }}) - unix_millis(date_trunc('DD', {{ datetime_field }}))
     {%- endset -%}
     {%- if datepart == 'millisecond' -%}
-        timestamp_millis(unix_millis({{ datetime_field }}) + {{ number }})
+        timestamp_millis(unix_millis({{ datetime_field }}) + {{ number_int }})
     {%- elif datepart == 'second' -%}
-        timestamp_millis(unix_millis({{ datetime_field }}) + {{ number }}*1000)
+        timestamp_millis(unix_millis({{ datetime_field }}) + {{ number_int }}*1000)
     {%- elif datepart == 'minute' -%}
-        timestamp_millis(unix_millis({{ datetime_field }}) + {{ number }}*60000)
+        timestamp_millis(unix_millis({{ datetime_field }}) + {{ number_int }}*60000)
     {%- elif datepart == 'hour' -%}
-        timestamp_millis(unix_millis({{ datetime_field }}) + {{ number }}*3600000)
+        timestamp_millis(unix_millis({{ datetime_field }}) + {{ number_int }}*3600000)
     {%- elif datepart == 'day' -%}
-        timestamp_millis(unix_millis(try_to_timestamp(date_add(to_date({{ datetime_field }}), {{ number }}))) + {{ time_field }})
+        timestamp_millis(unix_millis(try_to_timestamp(date_add(to_date({{ datetime_field }}), {{ number_int }}))) + {{ time_field }})
     {%- elif datepart == 'week' -%}
-        timestamp_millis(unix_millis(try_to_timestamp(date_add(to_date({{ datetime_field }}), {{ number }}*7))) + {{ time_field }})
+        timestamp_millis(unix_millis(try_to_timestamp(date_add(to_date({{ datetime_field }}), {{ number_int }}*7))) + {{ time_field }})
     {%- elif datepart == 'month' -%}
-        timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ datetime_field }}), {{ number }}))) + {{ time_field }})
+        timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ datetime_field }}), {{ number_int }}))) + {{ time_field }})
     {%- elif datepart == 'quarter' -%}
-        timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ datetime_field }}), {{ number }}*3))) + {{ time_field }})
+        timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ datetime_field }}), {{ number_int }}*3))) + {{ time_field }})
     {%- elif datepart == 'year' -%}
-        timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ datetime_field }}), {{ number }}*12))) + {{ time_field }})
+        timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ datetime_field }}), {{ number_int }}*12))) + {{ time_field }})
     {%- endif -%}
 {%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
## Description
Explicitly cast `number` to INT in the `dateadd` macro for the Databricks part. Without this cast, we cannot use the `dateadd` function with _day_, _week_, _month_, _quarter_ or _year_ in combination with the `to_integer` pm_utils macro. That last macro returns a `BIGINT` which is not accepted by the functions used in the implementation for the specified periods.

## Release
- [x] Direct release (`main`)
- [ ] Merge to `dev` (or other) branch
  - Why:

### Did you consider?
- [x] Does it Work on Automation Suite / SQL Server
- [x] Does it Work on Automation Cloud / Snowflake
~~- [ ] What is the performance impact?~~
- [x] The version number in `dbt_project.yml`
