### PR TITLE
Include spaces in charindex macro for SQL Server DNA-15944 [DNA-20911]

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'pm_utils'
-version: '1.1.1'
+version: '1.1.2'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/macros/multiple_databases/charindex.sql
+++ b/macros/multiple_databases/charindex.sql
@@ -1,6 +1,13 @@
 {%- macro charindex(expression_to_find, field, start_location=None) -%}
+{%- set expression_length -%}
+    {% if target.type == 'sqlserver' -%}
+        datalength('{{ expression_to_find }}')
+    {% else -%}
+        length('{{ expression_to_find }}')
+    {% endif -%}
+{%- endset -%}
 case
-    when len('{{ expression_to_find }}') > 0
+    when {{ expression_length }} > 0
     then
         {% if start_location is none -%}
             {% if target.type == 'databricks' -%}


### PR DESCRIPTION
## Description
- For the `charindex` macro, also account for spaces in SQL Server when checking if a field is `null` or not.

## Release
- [x] Direct release (`main`)
- [ ] Merge to `dev` (or other) branch
  - Why:

### Did you consider?
- [x] Does it Work on Automation Suite / SQL Server
- [x] Does it Work on Automation Cloud / Snowflake
- [x] What is the performance impact?
- [x] The version number in `dbt_project.yml`
