### PR TITLE
Add integration tests for charindex, dateadd, to_timestamp (DNA-19468 / DNA-20817)

### DIFF
--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -33,3 +33,24 @@ models:
       - equal_value:
           actual: '`Find_null_value`'
           expected: '`Find_null_value_expected`'
+
+  - name: test_to_timestamp
+    tests:
+      - equal_value:
+          actual: '`timestamp_date`'
+          expected: '`timestamp_date_expected`'
+      - equal_value:
+          actual: '`timestamp_datetime`'
+          expected: '`timestamp_datetime_expected`'
+      - equal_value:
+          actual: '`timestamp_datetime_ms`'
+          expected: '`timestamp_datetime_ms_expected`'
+      - equal_value:
+          actual: '`timestamp_datetime_ms4`'
+          expected: '`timestamp_datetime_ms4_expected`'
+      - equal_value:
+          actual: '`timestamp_time`'
+          expected: '`timestamp_time_expected`'
+      - equal_value:
+          actual: '`null_value`'
+          expected: '`null_value_expected`'

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -9,3 +9,27 @@ models:
       - equal_value:
           actual: '`One_null`'
           expected: '`One_null_expected`'
+
+  - name: test_charindex
+    tests:
+      - equal_value:
+          actual: '`Find_basic_scenario`'
+          expected: '`Find_basic_scenario_expected`'
+      - equal_value:
+          actual: '`Find_first_of_multiple_occurrences`'
+          expected: '`Find_first_of_multiple_occurrences_expected`'
+      - equal_value:
+          actual: '`Find_first_space`'
+          expected: '`Find_first_space_expected`'
+      - equal_value:
+          actual: '`Find_with_start_location`'
+          expected: '`Find_with_start_location_expected`'
+      - equal_value:
+          actual: '`Find_non_occurring_value`'
+          expected: '`Find_non_occurring_value_expected`'
+      - equal_value:
+          actual: '`Find_empty_value`'
+          expected: '`Find_empty_value_expected`'
+      - equal_value:
+          actual: '`Find_null_value`'
+          expected: '`Find_null_value_expected`'

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -54,3 +54,39 @@ models:
       - equal_value:
           actual: '`null_value`'
           expected: '`null_value_expected`'
+
+  - name: test_dateadd
+    tests:
+      - equal_value:
+          actual: '`add_milliseconds`'
+          expected: '`add_milliseconds_expected`'
+      - equal_value:
+          actual: '`add_seconds`'
+          expected: '`add_seconds_expected`'
+      - equal_value:
+          actual: '`add_minutes`'
+          expected: '`add_minutes_expected`'
+      - equal_value:
+          actual: '`add_hours`'
+          expected: '`add_hours_expected`'
+      - equal_value:
+          actual: '`add_days`'
+          expected: '`add_days_expected`'
+      - equal_value:
+          actual: '`add_weeks`'
+          expected: '`add_weeks_expected`'
+      - equal_value:
+          actual: '`add_months`'
+          expected: '`add_months_expected`'
+      - equal_value:
+          actual: '`add_quarters`'
+          expected: '`add_quarters_expected`'
+      - equal_value:
+          actual: '`add_years`'
+          expected: '`add_years_expected`'
+      - equal_value:
+          actual: '`add_bigint`'
+          expected: '`add_bigint_expected`'
+      - equal_value:
+          actual: '`add_to_null_value`'
+          expected: '`add_to_null_value_expected`'

--- a/integration_tests/models/test_charindex.sql
+++ b/integration_tests/models/test_charindex.sql
@@ -1,0 +1,35 @@
+with Input_data as (
+    select
+        'This is a text!' as `Text`
+)
+
+select
+    {# Find a substring (basic scenario) #}
+    {{ pm_utils.charindex('his', '`Text`') }} as `Find_basic_scenario`,
+    2 as `Find_basic_scenario_expected`,
+
+    {# Find a substring with multiple occurences #}
+    {{ pm_utils.charindex('is', '`Text`') }} as `Find_first_of_multiple_occurrences`,
+    3 as `Find_first_of_multiple_occurrences_expected`,
+
+    {# Find a space. Covering an edge case in SQL Server, spaces in values are ignored by default #}
+    {{ pm_utils.charindex(' ', '`Text`') }} as `Find_first_space`,
+    5 as `Find_first_space_expected`,
+
+    {# Find a substring with multiple occurences using a start location after the first occurence #}
+    {{ pm_utils.charindex('is', '`Text`', 4) }} as `Find_with_start_location`,
+    6 as `Find_with_start_location_expected`,
+
+    {# Find non occuring value #}
+    {{ pm_utils.charindex('x', '`Text`') }} as `Find_non_occurring_value`,
+    13 as `Find_non_occurring_value_expected`,
+
+    {# Find empty value #}
+    {{ pm_utils.charindex('', '`Text`') }} as `Find_empty_value`,
+    0 as `Find_empty_value_expected`,
+
+    {# Find null value #}
+    {{ pm_utils.charindex(null, '`Text`') }} as `Find_null_value`,
+    0 as `Find_null_value_expected`
+
+from Input_data

--- a/integration_tests/models/test_dateadd.sql
+++ b/integration_tests/models/test_dateadd.sql
@@ -1,0 +1,53 @@
+with Input_data as (
+    select
+        '2023-11-12 13:14:15.678' as `testdate`,
+        null as `null_value`,
+        {{ pm_utils.to_integer('1') }} as `bigint_value`
+        
+)
+
+select
+    {# Add milliseconds, seconds, minutes, hours, days, months and years #}
+    {{ pm_utils.to_varchar(pm_utils.dateadd('millisecond', 1, '`testdate`')) }} as `add_milliseconds`,
+    {{ pm_utils.to_varchar(pm_utils.dateadd('second', 1, '`testdate`')) }} as `add_seconds`,
+    {{ pm_utils.to_varchar(pm_utils.dateadd('minute', 1, '`testdate`')) }} as `add_minutes`,
+    {{ pm_utils.to_varchar(pm_utils.dateadd('hour', 1, '`testdate`')) }} as `add_hours`,
+    {{ pm_utils.to_varchar(pm_utils.dateadd('day', 1, '`testdate`')) }} as `add_days`,
+    {{ pm_utils.to_varchar(pm_utils.dateadd('week', 1, '`testdate`')) }} as `add_weeks`,
+    {{ pm_utils.to_varchar(pm_utils.dateadd('month', 1, '`testdate`')) }} as `add_months`,
+    {{ pm_utils.to_varchar(pm_utils.dateadd('quarter', 1, '`testdate`')) }} as `add_quarters`,
+    {{ pm_utils.to_varchar(pm_utils.dateadd('year', 1, '`testdate`')) }} as `add_years`,
+
+    {# Use bigint as the value #}
+    {{ pm_utils.to_varchar(pm_utils.dateadd('year', '`bigint_value`', '`testdate`')) }} as `add_bigint`,    
+
+    {% if target.type == 'sqlserver' %}
+        {# SQL Server uses datetime2 format, which has a precision of 7 digits #}
+        '2023-11-12 13:14:15.6790000' as `add_milliseconds_expected`,
+        '2023-11-12 13:14:16.6780000' as `add_seconds_expected`,
+        '2023-11-12 13:15:15.6780000' as `add_minutes_expected`,
+        '2023-11-12 14:14:15.6780000' as `add_hours_expected`,
+        '2023-11-13 13:14:15.6780000' as `add_days_expected`,
+        '2023-11-19 13:14:15.6780000' as `add_weeks_expected`,
+        '2023-12-12 13:14:15.6780000' as `add_months_expected`,
+        '2024-02-12 13:14:15.6780000' as `add_quarters_expected`,
+        '2024-11-12 13:14:15.6780000' as `add_years_expected`,
+        '2024-11-12 13:14:15.6780000' as `add_bigint_expected`,
+    {% else %}
+        '2023-11-12 13:14:15.679' as `add_milliseconds_expected`,
+        '2023-11-12 13:14:16.678' as `add_seconds_expected`,
+        '2023-11-12 13:15:15.678' as `add_minutes_expected`,
+        '2023-11-12 14:14:15.678' as `add_hours_expected`,
+        '2023-11-13 13:14:15.678' as `add_days_expected`,
+        '2023-11-19 13:14:15.678' as `add_weeks_expected`,
+        '2023-12-12 13:14:15.678' as `add_months_expected`,
+        '2024-02-12 13:14:15.678' as `add_quarters_expected`,
+        '2024-11-12 13:14:15.678' as `add_years_expected`,
+        '2024-11-12 13:14:15.678' as `add_bigint_expected`,
+    {% endif %}
+    
+    {# Use null as the date #}
+    {{ pm_utils.to_varchar(pm_utils.dateadd('year', 1, '`null_value`')) }} as `add_to_null_value`,
+    '' as `add_to_null_value_expected`
+
+from Input_data

--- a/integration_tests/models/test_to_timestamp.sql
+++ b/integration_tests/models/test_to_timestamp.sql
@@ -1,0 +1,44 @@
+with Input_data as (
+    select
+        '2023-11-12' as `timestamp_date`,
+        '2023-11-12 13:14:15' as `timestamp_datetime`,
+        '2023-11-12 13:14:15.678' as `timestamp_datetime_ms`,
+        '2023-11-12 13:14:15.6789' as `timestamp_datetime_ms4`,
+        '13:14:15' as `timestamp_time`,
+        null as `null_value`
+)
+
+select
+    {{ pm_utils.to_varchar(pm_utils.to_timestamp('`timestamp_date`')) }} as `timestamp_date`,
+    {{ pm_utils.to_varchar(pm_utils.to_timestamp('`timestamp_datetime`')) }} as `timestamp_datetime`,
+    {{ pm_utils.to_varchar(pm_utils.to_timestamp('`timestamp_datetime_ms`')) }} as `timestamp_datetime_ms`,
+    {{ pm_utils.to_varchar(pm_utils.to_timestamp('`timestamp_datetime_ms4`')) }} as `timestamp_datetime_ms4`,
+    {{ pm_utils.to_varchar(pm_utils.to_timestamp('`timestamp_time`')) }} as `timestamp_time`,
+    {{ pm_utils.to_varchar(pm_utils.to_timestamp('`null_value`')) }} as `null_value`,
+    
+    {% if target.type == 'databricks' %}
+        '' as `timestamp_date_expected`,
+        '2023-11-12 13:14:15' as `timestamp_datetime_expected`,
+        '2023-11-12 13:14:15.678' as `timestamp_datetime_ms_expected`,
+        '2023-11-12 13:14:15' as `timestamp_datetime_ms4_expected`,
+        '' as `timestamp_time_expected`,
+        '' as `null_value_expected`
+    {% elif target.type == 'sqlserver' %}
+        --SQL Server uses datetime2 format and always specifies the precision with 7 digits.
+        --SQL Server will also give a result when only having a date or a time as input
+        '2023-11-12 00:00:00.0000000' as `timestamp_date_expected`,
+        '2023-11-12 13:14:15.0000000' as `timestamp_datetime_expected`,
+        '2023-11-12 13:14:15.6780000' as `timestamp_datetime_ms_expected`,
+        '2023-11-12 13:14:15.6789000' as `timestamp_datetime_ms4_expected`,
+        '1900-01-01 13:14:15.0000000' as `timestamp_time_expected`,
+        '' as `null_value_expected`
+    {% elif target.type == 'snowflake' %}
+        '' as `timestamp_date_expected`,
+        '2023-11-12 13:14:15.000' as `timestamp_datetime_expected`,
+        '2023-11-12 13:14:15.678' as `timestamp_datetime_ms_expected`,
+        '2023-11-12 13:14:15.678' as `timestamp_datetime_ms4_expected`,
+        '' as `timestamp_time_expected`,
+        '' as `null_value_expected`
+    {% endif %}
+    
+from Input_data


### PR DESCRIPTION
## Description
- Adds integration tests for `charindex`, `dateadd` and `to_timestamp` macro's

## Release
- [X] Direct release (`main`)
- [ ] Merge to `dev` (or other) branch
  - Why:

### Did you consider?
- [X] Does it Work on Automation Suite / SQL Server
- [X] Does it Work on Automation Cloud / Snowflake
~~- [ ] What is the performance impact?~~
~~- [ ] The version number in `dbt_project.yml`~~
