### PR TITLE
fix: dateadd supports more than 25 days for every unit of time (DNA-21769: DNA-21829)

### DIFF
--- a/.pipelines/azure-pipelines-integration-tests.yml
+++ b/.pipelines/azure-pipelines-integration-tests.yml
@@ -84,11 +84,16 @@ jobs:
           sudo pip install --upgrade cffi
 
           python3 -m venv dbt-env
-          source dbt-env/bin/activate
+          python3 -m venv dbt-env-sqlserver
 
-          pip install dbt-databricks==1.4.3
+          source dbt-env/bin/activate
+          pip install databricks-sql-connector==2.9.3
+          pip install dbt-databricks==1.7.1
+          pip install dbt-snowflake==1.7.0
+          dbt --version
+
+          source dbt-env-sqlserver/bin/activate
           pip install dbt-sqlserver==1.4.3
-          pip install dbt-snowflake==1.4.3
           dbt --version
         displayName: Install dbt
 
@@ -112,7 +117,7 @@ jobs:
         displayName: Install dbt dependencies (double quotes) 
 
       - bash: |
-          source dbt-env/bin/activate
+          source dbt-env-sqlserver/bin/activate
           cd $(dbtProjectPathQuotes)
           dbt build --profiles-dir $(Agent.BuildDirectory)/self/.pipelines --profile default -t sqlserver-ci \
             --vars '{"schema_sources": "$(DBT_SCHEMA_SOURCES)", "DBT_SQL_SERVER_SERVER": "$(DBT_SQL_SERVER_SERVER)", "DBT_SQL_SERVER_USER": "$(DBT_SQL_SERVER_USER)", "DBT_SQL_SERVER_PASSWORD": "$(DBT_SQL_SERVER_PASSWORD)", "DBT_SQL_SERVER_DATABASE": "$(DBT_SQL_SERVER_DATABASE)", "DBT_SCHEMA": "$(DBT_SCHEMA)"}'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This dbt package contains macros for SQL functions to run the dbt project on mul
   - [as_varchar](#as_varchar-source)
   - [charindex](#charindex-source)
   - [create_index](#create_index-source)
-  - [date_add](#date_add-source)
+  - [dateadd](#dateadd-source)
   - [date_from_timestamp](#date_from_timestamp-source)
   - [datediff](#datediff-source)
   - [stddev](#stddev-source)
@@ -89,10 +89,10 @@ In case you want to create the index on a source table, refer to the table using
 ```
 
 #### dateadd ([source](macros/multiple_databases/dateadd.sql))
-This macro adds a specified number value (as a signed integer) of the specified datepart to an input date or datetime and then returns that modified value. The datepart can be any of the following values: year, quarter, month, week, day, hour, minute, second, millisecond.
+This macro adds the specified number of units for the `datepart` to a date or datetime expression. The `datepart` can be any of the following values: year, quarter, month, week, day, hour, minute, second, millisecond. The number of units will be interpreted as an integer value.
 
 Usage: 
-`{{ pm_utils.dateadd('[datepart]', [number], '[expression]') }}`
+`{{ pm_utils.dateadd('[datepart]', '[number]', '[date_expression]') }}`
 
 #### date_from_timestamp ([source](macros/multiple_databases/date_from_timestamp.sql))
 This macro extracts the date part from a datetime field. 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'pm_utils'
-version: '1.2.0'
+version: '1.2.1'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -97,6 +97,9 @@ models:
           actual: '`add_bigint_30_days`'
           expected: '`add_bigint_30_days_expected`'
       - equal_value:
+          actual: '`add_double_days`'
+          expected: '`add_double_days_expected`'
+      - equal_value:
           actual: '`add_to_null_value`'
           expected: '`add_to_null_value_expected`'
 

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -85,8 +85,17 @@ models:
           actual: '`add_years`'
           expected: '`add_years_expected`'
       - equal_value:
+          actual: '`add_30_days_in_days`'
+          expected: '`add_30_days_in_days_expected`'
+      - equal_value:
+          actual: '`add_30_days_in_seconds`'
+          expected: '`add_30_days_in_seconds_expected`'
+      - equal_value:
           actual: '`add_bigint`'
           expected: '`add_bigint_expected`'
+      - equal_value:
+          actual: '`add_bigint_30_days`'
+          expected: '`add_bigint_30_days_expected`'
       - equal_value:
           actual: '`add_to_null_value`'
           expected: '`add_to_null_value_expected`'

--- a/integration_tests/models/test_dateadd.sql
+++ b/integration_tests/models/test_dateadd.sql
@@ -2,12 +2,12 @@ with Input_data as (
     select
         '2023-11-12 13:14:15.678' as `testdate`,
         null as `null_value`,
-        {{ pm_utils.to_integer('1') }} as `bigint_value`
-        
+        {{ pm_utils.to_integer('1') }} as `bigint_value`,
+        {{ pm_utils.to_integer('30') }} as `bigint_value_30`,
 )
 
 select
-    {# Add milliseconds, seconds, minutes, hours, days, months and years #}
+    {# Add 1 unit for every possible dateparts. #}
     {{ pm_utils.to_varchar(pm_utils.dateadd('millisecond', 1, '`testdate`')) }} as `add_milliseconds`,
     {{ pm_utils.to_varchar(pm_utils.dateadd('second', 1, '`testdate`')) }} as `add_seconds`,
     {{ pm_utils.to_varchar(pm_utils.dateadd('minute', 1, '`testdate`')) }} as `add_minutes`,
@@ -18,8 +18,13 @@ select
     {{ pm_utils.to_varchar(pm_utils.dateadd('quarter', 1, '`testdate`')) }} as `add_quarters`,
     {{ pm_utils.to_varchar(pm_utils.dateadd('year', 1, '`testdate`')) }} as `add_years`,
 
-    {# Use bigint as the value #}
-    {{ pm_utils.to_varchar(pm_utils.dateadd('year', '`bigint_value`', '`testdate`')) }} as `add_bigint`,    
+    {# Add 30 days to cover the scenario a bigint is required to store the amount of milliseconds. #}
+    {{ pm_utils.to_varchar(pm_utils.dateadd('day', 30, '`testdate`')) }} as `add_30_days_in_days`,
+    {{ pm_utils.to_varchar(pm_utils.dateadd('second', 2592000, '`testdate`')) }} as `add_30_days_in_seconds`,
+
+    {# Use a bigint datatype as the input for number of units to be added. #}
+    {{ pm_utils.to_varchar(pm_utils.dateadd('year', '`bigint_value`', '`testdate`')) }} as `add_bigint`,
+    {{ pm_utils.to_varchar(pm_utils.dateadd('day', '`bigint_value_30`', '`testdate`')) }} as `add_bigint_30_days`,
 
     {% if target.type == 'sqlserver' %}
         {# SQL Server uses datetime2 format, which has a precision of 7 digits #}
@@ -32,7 +37,10 @@ select
         '2023-12-12 13:14:15.6780000' as `add_months_expected`,
         '2024-02-12 13:14:15.6780000' as `add_quarters_expected`,
         '2024-11-12 13:14:15.6780000' as `add_years_expected`,
+        '2023-12-12 13:14:15.6780000' as `add_30_days_in_days_expected`,
+        '2023-12-12 13:14:15.6780000' as `add_30_days_in_seconds_expected`,
         '2024-11-12 13:14:15.6780000' as `add_bigint_expected`,
+        '2023-12-12 13:14:15.6780000' as `add_bigint_30_days_expected`,
     {% else %}
         '2023-11-12 13:14:15.679' as `add_milliseconds_expected`,
         '2023-11-12 13:14:16.678' as `add_seconds_expected`,
@@ -43,7 +51,10 @@ select
         '2023-12-12 13:14:15.678' as `add_months_expected`,
         '2024-02-12 13:14:15.678' as `add_quarters_expected`,
         '2024-11-12 13:14:15.678' as `add_years_expected`,
+        '2023-12-12 13:14:15.678' as `add_30_days_in_days_expected`,
+        '2023-12-12 13:14:15.678' as `add_30_days_in_seconds_expected`,
         '2024-11-12 13:14:15.678' as `add_bigint_expected`,
+        '2023-12-12 13:14:15.678' as `add_bigint_30_days_expected`,
     {% endif %}
     
     {# Use null as the date #}

--- a/macros/multiple_databases/dateadd.sql
+++ b/macros/multiple_databases/dateadd.sql
@@ -22,12 +22,13 @@
         timestamp_millis(unix_millis(try_to_timestamp({{ date_or_datetime_field }})) + {{ number_bigint }} * 1000 * 60 * 60 * 24)
     {%- elif datepart == 'week' -%}
         timestamp_millis(unix_millis(try_to_timestamp({{ date_or_datetime_field }})) + {{ number_bigint }} * 1000 * 60 * 60 * 24 * 7)
+    {%- endif -%}
     {# Since the number of days in a month can differ, use the add_months function for month, quarter and year.
     Add the time part separately because add_months needs dates as input. Both parts are converted to milliseconds to do the addition. #}
     {%- set time_in_milliseconds -%}
         unix_millis(try_to_timestamp({{ date_or_datetime_field }})) - unix_millis(date_trunc('DD', try_to_timestamp({{ date_or_datetime_field }})))
     {%- endset -%}
-    {%- elif datepart == 'month' -%}
+    {%- if datepart == 'month' -%}
         timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ date_or_datetime_field }}), {{ number_bigint }}))) + {{ time_in_milliseconds }})
     {%- elif datepart == 'quarter' -%}
         timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ date_or_datetime_field }}), {{ number_bigint }} * 3))) + {{ time_in_milliseconds }})

--- a/macros/multiple_databases/dateadd.sql
+++ b/macros/multiple_databases/dateadd.sql
@@ -8,32 +8,35 @@
     {%- set number_bigint -%}
         try_cast({{ number }} as bigint)
     {%- endset -%}
-    {# Convert the base date and the units to be added both to milliseconds to do the addition.
+    {# Convert the base timestamp and the units to be added both to milliseconds to do the addition.
     Convert the total milliseconds back to a timestamp using timestamp_millis. #}
+    {%- set base_timestamp_in_ms -%}
+        unix_millis(try_to_timestamp({{ date_or_datetime_field }}))
+    {%- endset -%}
     {%- if datepart == 'millisecond' -%}
-        timestamp_millis(unix_millis(try_to_timestamp({{ date_or_datetime_field }})) + {{ number_bigint }})
+        timestamp_millis({{ base_timestamp_in_ms }} + {{ number_bigint }})
     {%- elif datepart == 'second' -%}
-        timestamp_millis(unix_millis(try_to_timestamp({{ date_or_datetime_field }})) + {{ number_bigint }} * 1000)
+        timestamp_millis({{ base_timestamp_in_ms }} + {{ number_bigint }} * 1000)
     {%- elif datepart == 'minute' -%}
-        timestamp_millis(unix_millis(try_to_timestamp({{ date_or_datetime_field }})) + {{ number_bigint }} * 1000 * 60)
+        timestamp_millis({{ base_timestamp_in_ms }} + {{ number_bigint }} * 1000 * 60)
     {%- elif datepart == 'hour' -%}
-        timestamp_millis(unix_millis(try_to_timestamp({{ date_or_datetime_field }})) + {{ number_bigint }} * 1000 * 60 * 60)
+        timestamp_millis({{ base_timestamp_in_ms }} + {{ number_bigint }} * 1000 * 60 * 60)
     {%- elif datepart == 'day' -%}
-        timestamp_millis(unix_millis(try_to_timestamp({{ date_or_datetime_field }})) + {{ number_bigint }} * 1000 * 60 * 60 * 24)
+        timestamp_millis({{ base_timestamp_in_ms }} + {{ number_bigint }} * 1000 * 60 * 60 * 24)
     {%- elif datepart == 'week' -%}
-        timestamp_millis(unix_millis(try_to_timestamp({{ date_or_datetime_field }})) + {{ number_bigint }} * 1000 * 60 * 60 * 24 * 7)
+        timestamp_millis({{ base_timestamp_in_ms }} + {{ number_bigint }} * 1000 * 60 * 60 * 24 * 7)
     {%- endif -%}
     {# Since the number of days in a month can differ, use the add_months function for month, quarter and year.
-    Add the time part separately because add_months needs dates as input. Both parts are converted to milliseconds to do the addition. #}
-    {%- set time_in_milliseconds -%}
-        unix_millis(try_to_timestamp({{ date_or_datetime_field }})) - unix_millis(date_trunc('DD', try_to_timestamp({{ date_or_datetime_field }})))
+    The add_months function needs a date as input. Compute the milliseconds of the date and time part separately and add them together. #}
+    {%- set time_part_in_ms -%}
+        {{ base_timestamp_in_ms }} - unix_millis(date_trunc('DD', try_to_timestamp({{ date_or_datetime_field }})))
     {%- endset -%}
     {%- if datepart == 'month' -%}
-        timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ date_or_datetime_field }}), {{ number_bigint }}))) + {{ time_in_milliseconds }})
+        timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ date_or_datetime_field }}), {{ number_bigint }}))) + {{ time_part_in_ms }})
     {%- elif datepart == 'quarter' -%}
-        timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ date_or_datetime_field }}), {{ number_bigint }} * 3))) + {{ time_in_milliseconds }})
+        timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ date_or_datetime_field }}), {{ number_bigint }} * 3))) + {{ time_part_in_ms }})
     {%- elif datepart == 'year' -%}
-        timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ date_or_datetime_field }}), {{ number_bigint }} * 12))) + {{ time_in_milliseconds }})
+        timestamp_millis(unix_millis(try_to_timestamp(add_months(to_date({{ date_or_datetime_field }}), {{ number_bigint }} * 12))) + {{ time_part_in_ms }})
     {%- endif -%}
 {%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
## Description
- To fix the bug: the `number` argument is casted to a `bigint` for Databricks. Only for Databricks we do computations on this argument which can result in (negative) overflow values when the `number` is of type `int` instead of `bigint`. 
- Simplified the implementation:
  - Replaced the `date_add` used for `day` and `week` with the same approach as for the more granular units. We now have 2 different approaches instead of 3 to cover all scenarios.
  - Moved the "Jinja set variables" to places more close to where it is used.
- Docs: updated the readme to fix the table of contents and removed the condition that the number of units should be an integer.
- Added tests:
  - Additions of more than 25 days. Both in seconds, which we use ourselves, but also in days as this seems to be a more standard scenario.
  - Additions of doubles. This is also supported and used, although the values differ per database as doubles are rounded differently.

## Release
- [x] Direct release (`main`)
- [ ] Merge to `dev` (or other) branch
  - Why:

### Did you consider?
- [x] Does it Work on Automation Suite / SQL Server
- [x] Does it Work on Automation Cloud / Snowflake
- [x] What is the performance impact?
- [x] The version number in `dbt_project.yml`
