### PR TITLE
test: set configuration similar to app templates dbt projects (DNA-23644: DNA-25720)

### DIFF
--- a/.pipelines/azure-pipelines-integration-tests.yml
+++ b/.pipelines/azure-pipelines-integration-tests.yml
@@ -106,7 +106,7 @@ jobs:
           source dbt-env/bin/activate
           cd $(dbtProjectPath)
           dbt build --profiles-dir $(Agent.BuildDirectory)/self/.pipelines --profile default -t databricks-ci \
-            --vars '{"schema_sources": "$(DBT_SCHEMA_SOURCES)", "DBT_DATABRICKS_CATALOG": "$(DBT_DATABRICKS_CATALOG)", "DBT_DATABRICKS_HOST": "$(DBT_DATABRICKS_HOST)", "DBT_DATABRICKS_HTTP_PATH": "$(DBT_DATABRICKS_HTTP_PATH)", "DBT_DATABRICKS_TOKEN": "$(DBT_DATABRICKS_TOKEN)", "DBT_SCHEMA": "$(DBT_SCHEMA)"}'
+            --vars '{"DBT_DATABRICKS_CATALOG": "$(DBT_DATABRICKS_CATALOG)", "DBT_DATABRICKS_HOST": "$(DBT_DATABRICKS_HOST)", "DBT_DATABRICKS_HTTP_PATH": "$(DBT_DATABRICKS_HTTP_PATH)", "DBT_DATABRICKS_TOKEN": "$(DBT_DATABRICKS_TOKEN)", "DBT_SCHEMA": "$(DBT_SCHEMA)"}'
         displayName: Test (Databricks)
 
       - bash: |
@@ -119,12 +119,12 @@ jobs:
           source dbt-env-sqlserver/bin/activate
           cd $(dbtProjectPathQuotes)
           dbt build --profiles-dir $(Agent.BuildDirectory)/self/.pipelines --profile default -t sqlserver-ci \
-            --vars '{"schema_sources": "$(DBT_SCHEMA_SOURCES)", "DBT_SQL_SERVER_SERVER": "$(DBT_SQL_SERVER_SERVER)", "DBT_SQL_SERVER_USER": "$(DBT_SQL_SERVER_USER)", "DBT_SQL_SERVER_PASSWORD": "$(DBT_SQL_SERVER_PASSWORD)", "DBT_SQL_SERVER_DATABASE": "$(DBT_SQL_SERVER_DATABASE)", "DBT_SCHEMA": "$(DBT_SCHEMA)"}'
+            --vars '{"DBT_SQL_SERVER_SERVER": "$(DBT_SQL_SERVER_SERVER)", "DBT_SQL_SERVER_USER": "$(DBT_SQL_SERVER_USER)", "DBT_SQL_SERVER_PASSWORD": "$(DBT_SQL_SERVER_PASSWORD)", "DBT_SQL_SERVER_DATABASE": "$(DBT_SQL_SERVER_DATABASE)", "DBT_SCHEMA": "$(DBT_SCHEMA)"}'
         displayName: Test (SQL Server)
 
       - bash: |
           source dbt-env/bin/activate
           cd $(dbtProjectPathQuotes)
           dbt build --profiles-dir $(Agent.BuildDirectory)/self/.pipelines --profile default -t snowflake-ci \
-            --vars '{"schema_sources": "$(DBT_SCHEMA_SOURCES)", "DBT_SNOWFLAKE_ACCOUNT": "$(DBT_SNOWFLAKE_ACCOUNT)", "DBT_SNOWFLAKE_USER": "$(DBT_SNOWFLAKE_USER)", "DBT_SNOWFLAKE_PASSWORD": "$(DBT_SNOWFLAKE_PASSWORD)", "DBT_SNOWFLAKE_ROLE": "$(DBT_SNOWFLAKE_ROLE)", "DBT_SNOWFLAKE_DATABASE": "$(DBT_SNOWFLAKE_DATABASE)", "DBT_SNOWFLAKE_WAREHOUSE": "$(DBT_SNOWFLAKE_WAREHOUSE)", "DBT_SCHEMA": "$(DBT_SCHEMA)"}'
+            --vars '{"DBT_SNOWFLAKE_ACCOUNT": "$(DBT_SNOWFLAKE_ACCOUNT)", "DBT_SNOWFLAKE_USER": "$(DBT_SNOWFLAKE_USER)", "DBT_SNOWFLAKE_PASSWORD": "$(DBT_SNOWFLAKE_PASSWORD)", "DBT_SNOWFLAKE_ROLE": "$(DBT_SNOWFLAKE_ROLE)", "DBT_SNOWFLAKE_DATABASE": "$(DBT_SNOWFLAKE_DATABASE)", "DBT_SNOWFLAKE_WAREHOUSE": "$(DBT_SNOWFLAKE_WAREHOUSE)", "DBT_SCHEMA": "$(DBT_SCHEMA)"}'
         displayName: Test (Snowflake)

--- a/README.md
+++ b/README.md
@@ -141,13 +141,15 @@ You can choose to exclude fields from the select statement, for example:
 - When you apply logic to a field and don't want to keep the original.
 - When you join tables and a field with the same name is available on multiple tables.
 
+Make sure to put the relation also in the from clause. Otherwise, the table from which you select can't be found.
+
 Usage:
 
 Select all fields from model `Table_A`.
 ```
 select
     {{ pm_utils.star(ref('Table_A')) }}
-from ref('Table_A')
+from {{ ref('Table_A') }}
 ```
 
 Select all fields from source `Table_A`.
@@ -157,23 +159,12 @@ select
 from source('sources', 'Table_A')
 ```
 
-Select all fields from `Table_A`, which is first created as CTE. You can write `from Table_A`, but the argument of the star macro requires the `ref()`.
-```
-with Table_A as (
-    select * from {{ ref('Table_A') }}
-)
-
-select
-    {{ pm_utils.star(ref('Table_A')) }}
-from Table_A
-```
-
 Select all fields from `Table_A`, except for the field `Creation_date`. More fields can be added to the except list. Additional select statements can be written before and after the `star()` macro by separating the statements with a comma.
 ```
 select
     {{ pm_utils.star(ref('Table_A'), except=['Creation_date']) }},
     {{ pm_utils.to_date('"Creation_date"') }} as "Creation_date"
-from Table_A
+from {{ ref('Table_A') }}
 ```
 
 ### Data type cast functions

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'pm_utils'
-version: '1.4.0'
+version: '1.4.1'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -3,3 +3,14 @@ version: '1.0.0'
 config-version: 2
 
 profile: 'integration_tests'
+
+# All models are materialized as table.
+models:
+  pm_utils_integration_tests:
+    materialized: table
+
+# Quoting is enabled for databases, schemas, and identifiers.
+quoting:
+  database: true
+  schema: true
+  identifier: true

--- a/macros/SQL_generators/star.sql
+++ b/macros/SQL_generators/star.sql
@@ -8,9 +8,9 @@
     {%- for column in columns -%}
         {%- if column.name not in except -%}
             {%- if target.type == 'databricks' -%}
-                {%- set selects = selects.append(relation.identifier + '.`' + column.name + '`') -%}
+                {%- set selects = selects.append('`' + relation.identifier + '`.`' + column.name + '`') -%}
             {%- elif target.type in ('sqlserver', 'snowflake') -%}
-                {%- set selects = selects.append(relation.identifier + '."' + column.name + '"') -%}
+                {%- set selects = selects.append('"' + relation.identifier + '"."' + column.name + '"') -%}
             {%- endif -%}
         {%- endif -%}
     {%- endfor -%}
@@ -23,7 +23,11 @@
         {%- endif -%}
     {% endfor %}
 {% else %}
-    {{ relation.identifier }}.*
+    {%- if target.type == 'databricks' -%}
+        `{{ relation.identifier }}`.*
+    {%- elif target.type in ('sqlserver', 'snowflake') -%}
+        "{{ relation.identifier }}".*
+    {%- endif -%}
 {% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
## Description
- Make dbt configuration similar to app templates: enable quoting and materialize as table.
- Fix quotes on the star macro for the relation identifier.

## Release
- [x] Direct release (`main`)
- [ ] Merge to `dev` (or other) branch
  - Why:

### Did you consider?
- [x] Does it Work on Automation Suite / SQL Server
- [x] Does it Work on Automation Cloud / Snowflake
- [x] What is the performance impact?
- [x] The version number in `dbt_project.yml`
