### PR TITLE
feat: extend optional id by also generating id when all null (DNA-37255)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ These variables are only required when the `data_type` is used with the values `
 #### optional ([source](macros/SQL_generators/optional.sql))
 This macro checks in a table whether a column is present. If the column is not present, it creates the column with `null` values. If the column is present, it selects the column from the table. Use this macro to allow for missing columns in your source tables when that data is optional. Use the optional argument `data_type` to indicate the data type of the column. Possible values are: `boolean`, `date`, `double`, `integer`, `datetime`, and `text`. When no data type is set, the column is considered to be text.
 
-You can also set `id` as data type, which creates the column with unique integer values if the column is not present. If the column is present in that case, the values are expected to be integers.
+You can also set `id` as data type, which creates the column with unique integer values if the column is not present or when it only contains null values. If the column is present, the values are expected to be integers.
 
 Usage:
 `{{ pm_utils.optional(source('source_name', 'table_name'), '"Column_A"', 'data_type') }}`

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'pm_utils'
-version: '2.1.0'
+version: '2.2.0'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]


### PR DESCRIPTION
## Description
Generate an id value when all values in the source field are null.
- When the field doesn't exist, create it with a unique id.
- When the field has at least one value, apply type casting to integer.

## Release
- [x] Direct release (`main`)
- [ ] Merge to `dev` (or other) branch
  - Why:

### Did you consider?
- [x] Does it Work on Automation Suite / SQL Server
- [x] Does it Work on Automation Cloud / Snowflake
- [x] What is the performance impact?
- [x] The version number in `dbt_project.yml`
