### PR TITLE
fix: dont apply type casting to selected id field (DNA-38818)

### DIFF
--- a/.pipelines/azure-pipelines-integration-tests.yml
+++ b/.pipelines/azure-pipelines-integration-tests.yml
@@ -109,13 +109,13 @@ jobs:
           python3 -m venv dbt-env-sqlserver
 
           source dbt-env/bin/activate
-          pip install dbt-core==1.8.8
-          pip install dbt-snowflake==1.8.4
+          pip install dbt-core==1.9.4
+          pip install dbt-snowflake==1.9.1
           dbt --version
 
           source dbt-env-sqlserver/bin/activate
-          pip install dbt-core==1.8.8
-          pip install dbt-sqlserver==1.8.5
+          pip install dbt-core==1.9.4
+          pip install dbt-sqlserver==1.8.7
           dbt --version
         displayName: Install dbt
 

--- a/.pipelines/azure-pipelines-integration-tests.yml
+++ b/.pipelines/azure-pipelines-integration-tests.yml
@@ -18,7 +18,7 @@ pr:
     - '*'
 
 pool:
-  vmImage: ubuntu-latest
+  vmImage: ubuntu-22.04
 
 jobs:
   - job: get_keyvault_secrets

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'pm_utils'
-version: '2.3.0'
+version: '2.3.1'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/integration_tests/models/schema.yml
+++ b/integration_tests/models/schema.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: test_concat
-    tests:
+    data_tests:
       - equal_value:
           actual: '"Two_text_fields"'
           expected: '"Two_text_fields_expected"'
@@ -11,7 +11,7 @@ models:
           expected: '"One_null_expected"'
 
   - name: test_charindex
-    tests:
+    data_tests:
       - equal_value:
           actual: '"Find_basic_scenario"'
           expected: '"Find_basic_scenario_expected"'
@@ -35,7 +35,7 @@ models:
           expected: '"Find_null_value_expected"'
 
   - name: test_to_timestamp
-    tests:
+    data_tests:
       - equal_value:
           actual: '"timestamp_date"'
           expected: '"timestamp_date_expected"'
@@ -56,7 +56,7 @@ models:
           expected: '"null_value_expected"'
 
   - name: test_dateadd
-    tests:
+    data_tests:
       - equal_value:
           actual: '"add_milliseconds"'
           expected: '"add_milliseconds_expected"'
@@ -104,7 +104,7 @@ models:
           expected: '"add_to_null_value_expected"'
 
   - name: test_stddev
-    tests:
+    data_tests:
     - equal_value:
         actual: '"stddev_actual"'
         expected: '"stddev_expected"'
@@ -113,7 +113,7 @@ models:
         expected: '"stddev_with_null_values_expected"'
 
   - name: test_datediff
-    tests:
+    data_tests:
     - equal_value:
         actual: '"Year"'
         expected: '"Year_expected"'
@@ -146,7 +146,7 @@ models:
         expected: '"Millisecond_expected"'
 
   - name: test_diff_weekdays
-    tests:
+    data_tests:
     - equal_value:
         actual: '"Two_weekends"'
         expected: '"Two_weekends_expected"'
@@ -173,7 +173,7 @@ models:
         expected: '"Only_weekend_expected"'
 
   - name: test_json
-    tests:
+    data_tests:
     - equal_value:
         actual: '"One_level_field"'
         expected: '"One_level_field_expected"'

--- a/macros/SQL_generators/mandatory.sql
+++ b/macros/SQL_generators/mandatory.sql
@@ -13,7 +13,7 @@
 {%- elif data_type == 'text' -%}
     {{ pm_utils.to_varchar(mandatory_column) }}
 {%- elif data_type == 'id' -%}
-    {{ pm_utils.to_integer(mandatory_column, relation) }}
+    {{ mandatory_column }}
 {%- else -%}
     {{ pm_utils.to_varchar(mandatory_column) }}
 {%- endif -%}

--- a/macros/SQL_generators/optional.sql
+++ b/macros/SQL_generators/optional.sql
@@ -67,7 +67,7 @@ Only check when relation exists to prevent dbt compile errors. #}
             {% endif %}
 
             {% if optional_column in column_names and record_count > 0 %}
-                {{ pm_utils.to_integer(column_value, relation) }}
+                {{ column_value }}
             {% else %}
                 {{ pm_utils.id() }}
             {% endif %}


### PR DESCRIPTION
## Description
ID data type fields don't need to be integers. Also text IDs are allowed.
Apply to both the optional and mandatory macro.

Impact: numeric fields remain numeric and text fields remain text. This prevents casting to numeric when the values are not numeric and therefore result in errors/null values.

## Release
- [x] Direct release (`main`)
- [ ] Merge to `dev` (or other) branch
  - Why:

### Did you consider?
- [ ] Does it Work on Automation Suite / SQL Server
- [ ] Does it Work on Automation Cloud / Snowflake
- [ ] What is the performance impact?
- [ ] The version number in `dbt_project.yml`
